### PR TITLE
automatically create release on push to master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,12 +187,17 @@ jobs:
           name: release-windows
           path: release-artifacts/windows
 
+      - name: Set version from date
+        run: |
+          VERSION=$(date +%Y.%m.%d)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
       - name: Create GitHub release from generated artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create master-${{ github.run_number }} \
-            --title "imFile build ${{ github.run_number }}" \
+          gh release create imFile-${{ env.VERSION }} \
+            --title "${{ env.VERSION }}" \
             --target ${{ github.sha }} \
             --notes "Automated build triggered by push to master branch." \
             release-artifacts/**/*


### PR DESCRIPTION
## Description

Automatically create a release on push to `master` branch.

Automatically version based on YYYY-MM-DD date  (e.g. `imFile-Setup-2026.3.29.exe`)

Example run on my fork:

- https://github.com/sukibaby/imfile-desktop/actions/runs/23695623531/job/69030615862
- https://github.com/sukibaby/imfile-desktop/releases/tag/imFile-2026.03.29

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?
