### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### 项目概述
+
+imFile 是一个基于 Electron + Vue 3 的全功能桌面下载管理器（Motrix 的 fork），支持 HTTP/FTP/BitTorrent/Magnet/ED2K 协议。
+
+### 开发环境要求
+
+- Node.js >= 24（通过 nvm 安装：`nvm install 24 && nvm use 24`）
+- pnpm 10.33.0（通过 corepack：`corepack enable && corepack prepare pnpm@10.33.0 --activate`）
+- 显示服务器（Xvfb 已预装在 Cloud Agent VM，DISPLAY=:1）
+
+### 常用命令
+
+| 命令 | 说明 |
+|------|------|
+| `pnpm install` | 安装依赖（postinstall 会自动运行 `electron-builder install-app-deps` 和 `lint:fix`） |
+| `pnpm run dev` | 启动开发模式（webpack dev server + Electron） |
+| `pnpm run lint` | 运行 ESLint 检查 |
+| `pnpm run lint:fix` | ESLint 自动修复 |
+
+### 运行注意事项
+
+1. **`pnpm run dev` 启动流程**：dev-runner.js 同时编译 renderer（端口 9080）和 main 进程，编译完成后自动启动 Electron（带 `--inspect=5858` 调试端口）。
+2. **aria2c 引擎**：Electron 主进程启动时会自动从 `extra/linux/x64/engine/aria2c` 生成子进程，通过 JSON-RPC（127.0.0.1:16800）通信。
+3. **goed2kd 引擎**：ED2K 下载引擎从 `extra/linux/x64/goed2kd` 启动，HTTP RPC 监听 127.0.0.1:18080。
+4. **D-Bus 错误**：容器环境中会出现 `Failed to connect to the bus` 错误，这是预期行为，不影响应用功能。
+5. **UPnP 错误**：Cloud Agent 环境中 UPnP/NAT-PMP 端口映射不可用，不影响基本下载功能。
+6. **`pnpm run pack` 不可用**：webpack-cli v7 移除了 `--node-env` 参数，pack 脚本存在兼容问题。开发中使用 `pnpm run dev` 即可。
+7. **无自动化测试**：项目未配置测试框架，验证通过 lint + 手动测试完成。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Add `AGENTS.md` file with Cursor Cloud-specific development instructions for future cloud agents. This includes:
- Project overview and architecture notes
- Required Node.js/pnpm versions
- Common development commands
- Non-obvious runtime caveats (D-Bus errors, UPnP, webpack-cli v7 incompatibility with pack scripts)

## Related Issues

N/A - Development environment setup documentation.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?

## Evidence

[imfile_hello_world_demo.mp4](https://cursor.com/agents/bc-4301f5dd-7bbe-4163-9b13-d55bc9cb7f4f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fimfile_hello_world_demo.mp4)

[imFile running with a download task added](https://cursor.com/agents/bc-4301f5dd-7bbe-4163-9b13-d55bc9cb7f4f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fimfile_task_added.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4301f5dd-7bbe-4163-9b13-d55bc9cb7f4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4301f5dd-7bbe-4163-9b13-d55bc9cb7f4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

