### PR TITLE
Update AGENTS.md: dynamic pnpm version, PATH precedence note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,8 @@ imFile 是一个基于 Electron + Vue 3 的全功能桌面下载管理器（Motr
 
 ### 开发环境要求
 
-- Node.js >= 24（通过 nvm 安装：`nvm install 24 && nvm use 24`）
-- pnpm 10.33.0（通过 corepack：`corepack enable && corepack prepare pnpm@10.33.0 --activate`）
+- Node.js >= 24（通过 nvm 安装：`nvm install 24`）
+- pnpm（版本由 `package.json` 中 `packageManager` 字段指定，通过 corepack 自动管理）
 - 显示服务器（Xvfb 已预装在 Cloud Agent VM，DISPLAY=:1）
 
 ### 常用命令
@@ -23,10 +23,11 @@ imFile 是一个基于 Electron + Vue 3 的全功能桌面下载管理器（Motr
 
 ### 运行注意事项
 
-1. **`pnpm run dev` 启动流程**：dev-runner.js 同时编译 renderer（端口 9080）和 main 进程，编译完成后自动启动 Electron（带 `--inspect=5858` 调试端口）。
-2. **aria2c 引擎**：Electron 主进程启动时会自动从 `extra/linux/x64/engine/aria2c` 生成子进程，通过 JSON-RPC（127.0.0.1:16800）通信。
-3. **goed2kd 引擎**：ED2K 下载引擎从 `extra/linux/x64/goed2kd` 启动，HTTP RPC 监听 127.0.0.1:18080。
-4. **D-Bus 错误**：容器环境中会出现 `Failed to connect to the bus` 错误，这是预期行为，不影响应用功能。
-5. **UPnP 错误**：Cloud Agent 环境中 UPnP/NAT-PMP 端口映射不可用，不影响基本下载功能。
-6. **`pnpm run pack` 不可用**：webpack-cli v7 移除了 `--node-env` 参数，pack 脚本存在兼容问题。开发中使用 `pnpm run dev` 即可。
-7. **无自动化测试**：项目未配置测试框架，验证通过 lint + 手动测试完成。
+1. **PATH 优先级**：Cloud Agent VM 中 `/exec-daemon/node` 可能指向旧版 Node。启动 dev 时需确保 nvm 的 Node 24 在 PATH 前面：`export PATH="$HOME/.nvm/versions/node/v24.*/bin:$PATH"`（update script 已处理）。
+2. **`pnpm run dev` 启动流程**：dev-runner.js 同时编译 renderer（端口 9080）和 main 进程，编译完成后自动启动 Electron（带 `--inspect=5858` 调试端口）。
+3. **aria2c 引擎**：Electron 主进程启动时会自动从 `extra/linux/x64/engine/aria2c` 生成子进程，通过 JSON-RPC（127.0.0.1:16800）通信。
+4. **goed2kd 引擎**：ED2K 下载引擎从 `extra/linux/x64/goed2kd` 启动，HTTP RPC 监听 127.0.0.1:18080。
+5. **D-Bus 错误**：容器环境中会出现 `Failed to connect to the bus` 错误，这是预期行为，不影响应用功能。
+6. **UPnP 错误**：Cloud Agent 环境中 UPnP/NAT-PMP 端口映射不可用，不影响基本下载功能。
+7. **`pnpm run pack` 不可用**：webpack-cli v7 移除了 `--node-env` 参数，pack 脚本存在兼容问题。开发中使用 `pnpm run dev` 即可。
+8. **无自动化测试**：项目未配置测试框架，验证通过 lint + 手动测试完成。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Update `AGENTS.md` to:
- Use dynamic pnpm version (read from `packageManager` field in package.json) instead of hardcoded version
- Add PATH precedence note: Cloud Agent VM's `/exec-daemon/node` may shadow nvm, need to prepend nvm path

## Related Issues

Follow-up to #337 after v2.0.6 dependency upgrade.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?

## Evidence

[imFile v2.0.6 running after dependency upgrade](https://cursor.com/agents/bc-4301f5dd-7bbe-4163-9b13-d55bc9cb7f4f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fimfile_v206_running.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4301f5dd-7bbe-4163-9b13-d55bc9cb7f4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4301f5dd-7bbe-4163-9b13-d55bc9cb7f4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

