### PR TITLE
chore: upgrade Electron from 41.10.0 to 42.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "css-loader": "^7.1.4",
     "css-minimizer-webpack-plugin": "^8.0.0",
     "del": "^8.0.1",
-    "electron": "41.10.0",
+    "electron": "42.6.1",
     "electron-builder": "^26.15.3",
     "electron-devtools-installer": "^4.0.0",
     "electron-is": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,7 +59,7 @@ importers:
         version: 2.5.0
       '@electron/remote':
         specifier: ^2.1.3
-        version: 2.1.3(electron@41.10.0)
+        version: 2.1.3(electron@42.6.1)
       '@element-plus/icons-vue':
         specifier: ^2.3.2
         version: 2.3.2(vue@3.5.39(typescript@6.0.3))
@@ -112,8 +112,8 @@ importers:
         specifier: ^8.0.1
         version: 8.0.1
       electron:
-        specifier: 41.10.0
-        version: 41.10.0
+        specifier: 42.6.1
+        version: 42.6.1
       electron-builder:
         specifier: ^26.15.3
         version: 26.15.3(electron-builder-squirrel-windows@26.15.3)
@@ -2746,8 +2746,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@41.10.0:
-    resolution: {integrity: sha512-KuPcYnZXtmUv89YbNyZoU+Hud8s/X724zrhUZ4RjUg1b0pE0ax0FzTCiM1Lo4Nmxf2vX25u8w055to8IxVWxsQ==}
+  electron@42.6.1:
+    resolution: {integrity: sha512-HR9yiOyl+kZpSAugjOpBNvKpoh1wNpTK4wl6geD9W9Xmo6L6IgEzVB/JKlbEUDdXYeqRaaEhTUSSfyQ/g9iXvQ==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -6534,9 +6534,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/remote@2.1.3(electron@41.10.0)':
+  '@electron/remote@2.1.3(electron@42.6.1)':
     dependencies:
-      electron: 41.10.0
+      electron: 42.6.1
 
   '@electron/universal@2.0.3':
     dependencies:
@@ -8658,7 +8658,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@41.10.0:
+  electron@42.6.1:
     dependencies:
       '@electron-internal/extract-zip': 1.0.4
       '@electron/get': 5.0.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

将 Electron 从 41.10.0 升级到 42.6.1（当前最新大版本 43 的前一个大版本）。

### Electron 42 破坏性变更分析

| 变更 | 是否影响本项目 |
|------|--------------|
| macOS 通知迁移到 UNNotification API（需代码签名） | ❌ 仅影响 macOS 发布包 |
| 不再通过 postinstall 下载二进制（改为 lazy download） | ❌ 无影响 |
| OSR 默认 deviceScaleFactor 改为 1.0 | ❌ 未使用 OSR |
| 移除 `Session.clearStorageData` 的 `quotas` 参数 | ❌ 未使用 |
| 移除 `ELECTRON_SKIP_BINARY_DOWNLOAD` 环境变量 | ❌ 未使用 |

代码无需任何修改即可兼容。

## Related Issues

N/A

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4301f5dd-7bbe-4163-9b13-d55bc9cb7f4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4301f5dd-7bbe-4163-9b13-d55bc9cb7f4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

