### PR TITLE
fix(task): 修复下载中列表为空与已完成记录无法删除 (fixes #358)

### DIFF
--- a/src/renderer/api/Api.js
+++ b/src/renderer/api/Api.js
@@ -7,6 +7,7 @@ import {
   compactUndefined,
   formatOptionsForEngine,
   mergeTaskResult,
+  isTaskDownloading,
   changeKeysToCamelCase,
   changeKeysToKebabCase
 } from '@shared/utils'
@@ -22,6 +23,15 @@ function isRpcMethodNotFound (err) {
   if (Number(err.code) === -32601) return true
   const msg = String(err.message || '').toLowerCase()
   return msg.includes('method not found')
+}
+
+function assertGoed2kdResponse (result) {
+  if (result && result.ok === false) {
+    const err = new Error(result.message || 'goed2kd request failed')
+    err.code = 1
+    throw err
+  }
+  return result
 }
 
 export default class Api {
@@ -141,15 +151,18 @@ export default class Api {
   }
 
   async pauseGoed2kdTask (hash) {
-    return ipcRenderer.invoke('goed2kd:pause-download', { hash })
+    const result = await ipcRenderer.invoke('goed2kd:pause-download', { hash })
+    return assertGoed2kdResponse(result)
   }
 
   async resumeGoed2kdTask (hash) {
-    return ipcRenderer.invoke('goed2kd:resume-download', { hash })
+    const result = await ipcRenderer.invoke('goed2kd:resume-download', { hash })
+    return assertGoed2kdResponse(result)
   }
 
   async removeGoed2kdTask (hash) {
-    return ipcRenderer.invoke('goed2kd:remove-download', { hash })
+    const result = await ipcRenderer.invoke('goed2kd:remove-download', { hash })
+    return assertGoed2kdResponse(result)
   }
 
   async startGoed2kSearch (params = {}) {
@@ -293,9 +306,7 @@ export default class Api {
           console.log('[imFile] fetch downloading task list data:', data)
           const result = mergeTaskResult(data)
           resolve(
-            result.filter(
-              (list) => list.completedLength !== list.totalLength
-            )
+            result.filter((list) => isTaskDownloading(list))
           )
         })
         .catch((err) => {
@@ -339,7 +350,11 @@ export default class Api {
           console.log('[imFile] fetch seeding task list data:', data)
           if (data.length > 0) {
             resolve(
-              data.filter((list) => list.completedLength === list.totalLength)
+              data.filter((list) => {
+                const totalLength = Number(list.totalLength) || 0
+                const completedLength = Number(list.completedLength) || 0
+                return totalLength > 0 && completedLength >= totalLength
+              })
             )
           } else {
             resolve([])
@@ -512,7 +527,13 @@ export default class Api {
   removeTaskRecord (params = {}) {
     const { gid } = params
     const args = compactUndefined([gid])
-    return this.client.call('removeDownloadResult', ...args)
+    return this.client.call('removeDownloadResult', ...args).catch((err) => {
+      // go-aria2 等精简内核可能未实现 removeDownloadResult
+      if (isRpcMethodNotFound(err)) {
+        return this.client.call('forceRemove', ...args)
+      }
+      throw err
+    })
   }
 
   multicall (method, params = {}) {

--- a/src/renderer/components/Task/Index.vue
+++ b/src/renderer/components/Task/Index.vue
@@ -356,8 +356,13 @@ export default {
         this.$msg.success(this.t('task.remove-record-success', {
           taskName
         }))
-      } catch ({ code }) {
-        if (code === 1) {
+      } catch (err) {
+        if (err && err.code === 1) {
+          this.$msg.error(this.t('task.remove-record-fail', {
+            taskName
+          }))
+        } else {
+          console.warn('[imFile] remove task record fail:', err)
           this.$msg.error(this.t('task.remove-record-fail', {
             taskName
           }))

--- a/src/renderer/store/modules/task.js
+++ b/src/renderer/store/modules/task.js
@@ -1,7 +1,7 @@
 import { ipcRenderer } from 'electron'
 import api from '@/api'
 import { EMPTY_STRING, POST_DOWNLOAD_ACTION, TASK_STATUS } from '@shared/constants'
-import { checkTaskIsBT, intersection } from '@shared/utils'
+import { checkTaskIsBT, intersection, isTaskDownloading } from '@shared/utils'
 import { adaptAria2Task, adaptGoed2kdTask } from '../taskAdapter'
 
 const resolveGoed2kdList = (resp) => {
@@ -17,6 +17,16 @@ const resolveGoed2kdList = (resp) => {
     if (Array.isArray(resp.data.transfers)) return resp.data.transfers
   }
   return []
+}
+
+const resolveCountKey = (listType) => {
+  if (listType === 'active') {
+    return 'downloading'
+  }
+  if (listType === 'stopped') {
+    return 'stoped'
+  }
+  return listType
 }
 
 const matchGoed2kdListByCurrentTab = (status, currentList) => {
@@ -182,8 +192,12 @@ const actions = {
   fetchAllList ({ commit }) {
     return api.fetchAllTaskList().then(data => {
       const downloadingList = data[0][0].concat(data[1][0])
-      const downloading = downloadingList.filter((item) => item.completedLength !== item.totalLength).length
-      const seeding = downloadingList.filter((item) => item.completedLength === item.totalLength).length
+      const downloading = downloadingList.filter((item) => isTaskDownloading(item)).length
+      const seeding = downloadingList.filter((item) => {
+        const totalLength = Number(item.totalLength) || 0
+        const completedLength = Number(item.completedLength) || 0
+        return totalLength > 0 && completedLength >= totalLength
+      }).length
       const waiting = data[1][0].length
       const stoped = data[2][0].filter((item) => String(item?.status || '').toLowerCase() !== TASK_STATUS.REMOVED).length
 
@@ -209,7 +223,7 @@ const actions = {
               if (listType !== 'all') {
                 commit('UPDATE_COUNT', {
                   ...state.count,
-                  [listType === 'active' ? 'downloading' : listType]: taskList.length
+                  [resolveCountKey(listType)]: taskList.length
                 })
               } else {
                 dispatch('fetchAllList')
@@ -239,7 +253,7 @@ const actions = {
         if (listType !== 'all') {
           commit('UPDATE_COUNT', {
             ...state.count,
-            [listType === 'active' ? 'downloading' : listType]: taskList.length
+            [resolveCountKey(listType)]: taskList.length
           })
         } else {
           dispatch('fetchAllList')
@@ -469,7 +483,9 @@ const actions = {
 
     const { ERROR, COMPLETE, REMOVED } = TASK_STATUS
     if ([ERROR, COMPLETE, REMOVED].indexOf(status) === -1) {
-      return
+      const err = new Error('task status is not removable')
+      err.code = 1
+      return Promise.reject(err)
     }
     const request = task.engine === 'goed2kd'
       ? api.removeTaskByEngine(task)

--- a/src/renderer/store/taskAdapter.js
+++ b/src/renderer/store/taskAdapter.js
@@ -1,41 +1,23 @@
-import { getTaskName } from '@shared/utils'
+import { getTaskName, normalizeTaskStatus } from '@shared/utils'
 
 const toNumber = (value, defaultValue = 0) => {
   const result = Number(value)
   return Number.isFinite(result) ? result : defaultValue
 }
 
-const normalizeGoed2kdStatus = (status = '') => {
-  const value = String(status || '').toLowerCase()
-  switch (value) {
-    case 'downloading':
-    case 'active':
-    case 'running':
-      return 'active'
-    case 'paused':
-    case 'pause':
-      return 'paused'
-    case 'finished':
-    case 'complete':
-    case 'completed':
-      return 'complete'
-    case 'error':
-    case 'failed':
-      return 'error'
-    default:
-      return 'waiting'
-  }
-}
+const normalizeGoed2kdStatus = (status = '') => normalizeTaskStatus(status)
 
 export const buildTaskKey = (engine, id) => `${engine}:${id}`
 
 export const adaptAria2Task = (task = {}) => {
   const id = task.gid || ''
+  const status = normalizeTaskStatus(task.status)
   return {
     ...task,
     engine: 'aria2',
     id,
     gid: id,
+    status,
     taskKey: buildTaskKey('aria2', id),
     raw: task
   }

--- a/src/shared/utils/index.js
+++ b/src/shared/utils/index.js
@@ -132,6 +132,52 @@ export const calcRatio = (totalLength, uploadLength) => {
   return result
 }
 
+/** 统一 aria2 / goed2kd 等引擎返回的任务状态字符串 */
+export const normalizeTaskStatus = (status = '') => {
+  const value = String(status || '').toLowerCase()
+  switch (value) {
+    case 'active':
+    case 'downloading':
+    case 'running':
+      return TASK_STATUS.ACTIVE
+    case 'waiting':
+    case 'queued':
+      return TASK_STATUS.WAITING
+    case 'paused':
+    case 'pause':
+      return TASK_STATUS.PAUSED
+    case 'complete':
+    case 'completed':
+    case 'finished':
+      return TASK_STATUS.COMPLETE
+    case 'error':
+    case 'failed':
+      return TASK_STATUS.ERROR
+    case 'removed':
+      return TASK_STATUS.REMOVED
+    default:
+      return value || TASK_STATUS.WAITING
+  }
+}
+
+/**
+ * 判断任务是否应出现在「下载中」列表。
+ * totalLength 为 0（元数据未就绪等）时不能仅用 completedLength !== totalLength，否则会被误过滤。
+ */
+export const isTaskDownloading = (task = {}) => {
+  const status = normalizeTaskStatus(task.status)
+  const { ACTIVE, WAITING, PAUSED, COMPLETE, ERROR, REMOVED } = TASK_STATUS
+  if ([COMPLETE, ERROR, REMOVED].includes(status)) {
+    return false
+  }
+  const totalLength = Number(task.totalLength) || 0
+  const completedLength = Number(task.completedLength) || 0
+  if (totalLength > 0) {
+    return completedLength < totalLength
+  }
+  return status === ACTIVE || status === WAITING || status === PAUSED
+}
+
 export const timeRemaining = (totalLength, completedLength, downloadSpeed) => {
   const remainingLength = totalLength - completedLength
   return Math.ceil(remainingLength / downloadSpeed)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

修复 #358 中报告的两个问题：

1. **下载中列表看不到任务**：`fetchDownloadingTaskList` 使用 `completedLength !== totalLength` 过滤，当 `totalLength === 0`（磁力链元数据未就绪等）时任务会被误过滤。新增 `isTaskDownloading` 工具函数，正确识别「总大小未知但仍处于下载/等待/暂停」的任务。
2. **已完成列表删除无反应**：
   - 统一 aria2 任务状态归一化，避免 `completed` 等变体导致 `removeTaskRecord` 静默跳过；
   - 状态不允许删除时返回 rejected Promise，不再误报成功；
   - go-aria2 未实现 `removeDownloadResult` 时回退 `forceRemove`；
   - goed2kd IPC 返回 `ok: false` 时抛出错误并在 UI 展示失败提示；
   - 修正 `stopped` 标签页计数键名 `stoped` 不一致问题。

## Related Issues

Fixes #358

### Checklist:

* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran app with your changes locally?
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e6bf8ab-8abf-4eb8-b1f5-add515a0f2cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e6bf8ab-8abf-4eb8-b1f5-add515a0f2cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

