### PR TITLE
fix(preference): 修复设置页保存无效与无成功提示 (fixes #294)

### DIFF
--- a/src/main/Application.js
+++ b/src/main/Application.js
@@ -1419,6 +1419,16 @@ export default class Application extends EventEmitter {
     }
   }
 
+  async savePreferenceViaIpc (config = {}) {
+    try {
+      this.savePreference(config)
+      return { ok: true }
+    } catch (err) {
+      logger.warn('[imFile] save preference failed:', err.message)
+      return { ok: false, message: err.message }
+    }
+  }
+
   handleCommands () {
     this.on('application:save-preference', this.savePreference)
 
@@ -1662,6 +1672,10 @@ export default class Application extends EventEmitter {
   handleIpcInvokes () {
     ipcMain.handle('application:post-download-action', async (event, action) => {
       return this.handlePostDownloadAction(action)
+    })
+
+    ipcMain.handle('application:save-preference', async (event, config = {}) => {
+      return this.savePreferenceViaIpc(config)
     })
 
     ipcMain.handle('get-app-config', async () => {

--- a/src/renderer/api/Api.js
+++ b/src/renderer/api/Api.js
@@ -139,7 +139,11 @@ export default class Api {
       console.info('[imFile] save config found illegal key: ', others)
     }
 
-    ipcRenderer.send('command', 'application:save-preference', config)
+    if (isEmpty(config)) {
+      return Promise.resolve({ ok: true })
+    }
+
+    return ipcRenderer.invoke('application:save-preference', config)
   }
 
   async addEd2kTask (ed2k) {

--- a/src/renderer/components/Preference/Advanced.vue
+++ b/src/renderer/components/Preference/Advanced.vue
@@ -560,6 +560,7 @@ import {
   convertLineToComma,
   diffConfig,
   generateRandomInt,
+  isTrackerSourceListChanged,
   isValidSsapiBaseUrlOptional,
   normalizeSsapiBaseUrl
 } from '@shared/utils'
@@ -871,17 +872,14 @@ export default {
       if (!formRef) {
         return
       }
-      // 勿使用 validate(async () => {})：Element Plus 对异步回调的校验链不完整时会导致
-      // 保存逻辑与提示不执行；改为同步回调并调用独立 async 方法。
-      formRef.validate((valid) => {
-        if (!valid) {
-          console.error('[imFile] preference form valid:', valid)
-          return
-        }
-        this.runAdvancedPreferenceSubmit().catch((e) => {
-          console.error('[imFile] runAdvancedPreferenceSubmit', e)
+      // Element Plus validate 返回 Promise；勿在 validate 回调中使用 async，避免校验链异常导致保存逻辑不执行。
+      Promise.resolve(formRef.validate())
+        .then(() => this.runAdvancedPreferenceSubmit())
+        .catch((e) => {
+          if (e !== false) {
+            console.error('[imFile] preference form validate/submit failed:', e)
+          }
         })
-      })
     },
     async runAdvancedPreferenceSubmit () {
       if (!isValidSsapiBaseUrlOptional(this.form.ssapiSearchBaseUrl)) {
@@ -905,6 +903,10 @@ export default {
       )
       if (origTrackerNorm !== nextTrackerNorm) {
         data.btTracker = this.form.btTracker
+      }
+
+      if (isTrackerSourceListChanged(this.formOriginal.trackerSource, this.form.trackerSource)) {
+        data.trackerSource = [...this.form.trackerSource]
       }
 
       let engineSwitched = false

--- a/src/renderer/components/Preference/Basic.vue
+++ b/src/renderer/components/Preference/Basic.vue
@@ -593,64 +593,75 @@ export default {
         })
     },
     submitForm (formName) {
-      this.$refs[formName].validate((valid) => {
-        if (!valid) {
-          console.error('[imFile] preference form valid:', valid)
-          return false
-        }
-
-        const data = {
-          ...diffConfig(this.formOriginal, this.form),
-          ...changedConfig.advanced
-        }
-
-        const {
-          autoHideWindow,
-          btAutoDownloadContent,
-          btTracker,
-          rpcListenPort
-        } = data
-
-        if ('btAutoDownloadContent' in data) {
-          data.followTorrent = btAutoDownloadContent
-          data.followMetalink = btAutoDownloadContent
-          data.pauseMetadata = !btAutoDownloadContent
-        }
-
-        if (btTracker) {
-          data.btTracker = reduceTrackerString(convertLineToComma(btTracker))
-        }
-
-        if (rpcListenPort === EMPTY_STRING) {
-          data.rpcListenPort = this.rpcDefaultPort
-        }
-
-        console.log('[imFile] preference changed data:', data)
-
-        this.$store.dispatch('preference/save', data)
-          .then(() => {
-            this.$store.dispatch('app/fetchEngineOptions')
-            this.syncFormConfig()
-            this.$msg.success(this.t('preferences.save-success-message'))
-          })
-          .catch(() => {
-            this.$msg.success(this.t('preferences.save-fail-message'))
-          })
-
-        changedConfig.basic = {}
-        changedConfig.advanced = {}
-
-        if (this.isRenderer) {
-          if ('autoHideWindow' in data) {
-            this.$electron.ipcRenderer.send('command',
-              'application:auto-hide-window', autoHideWindow)
+      const formRef = this.$refs[formName]
+      if (!formRef) {
+        return
+      }
+      Promise.resolve(formRef.validate())
+        .then(() => this.runBasicPreferenceSubmit())
+        .catch((e) => {
+          if (e !== false) {
+            console.error('[imFile] preference form validate/submit failed:', e)
           }
+        })
+    },
+    async runBasicPreferenceSubmit () {
+      const data = {
+        ...diffConfig(this.formOriginal, this.form),
+        ...changedConfig.advanced
+      }
 
-          if (checkIsNeedRestart(data)) {
-            this.$electron.ipcRenderer.send('command', 'application:relaunch')
-          }
+      const {
+        autoHideWindow,
+        btAutoDownloadContent,
+        btTracker,
+        rpcListenPort
+      } = data
+
+      if ('btAutoDownloadContent' in data) {
+        data.followTorrent = btAutoDownloadContent
+        data.followMetalink = btAutoDownloadContent
+        data.pauseMetadata = !btAutoDownloadContent
+      }
+
+      if (btTracker) {
+        data.btTracker = reduceTrackerString(convertLineToComma(btTracker))
+      }
+
+      if (rpcListenPort === EMPTY_STRING) {
+        data.rpcListenPort = this.rpcDefaultPort
+      }
+
+      console.log('[imFile] preference changed data:', data)
+
+      changedConfig.basic = {}
+      changedConfig.advanced = {}
+
+      if (isEmpty(data)) {
+        this.$msg.info(this.t('preferences.no-changes-to-save'))
+        return
+      }
+
+      try {
+        await this.$store.dispatch('preference/save', data)
+        await this.$store.dispatch('app/fetchEngineOptions')
+        this.syncFormConfig()
+        this.$msg.success(this.t('preferences.save-success-message'))
+      } catch (e) {
+        console.error('[imFile] preference save failed:', e)
+        this.$msg.error(this.t('preferences.save-fail-message'))
+      }
+
+      if (this.isRenderer) {
+        if ('autoHideWindow' in data) {
+          this.$electron.ipcRenderer.send('command',
+            'application:auto-hide-window', autoHideWindow)
         }
-      })
+
+        if (checkIsNeedRestart(data)) {
+          this.$electron.ipcRenderer.send('command', 'application:relaunch')
+        }
+      }
     },
     resetForm (formName) {
       this.syncFormConfig()

--- a/src/renderer/store/modules/preference.js
+++ b/src/renderer/store/modules/preference.js
@@ -43,14 +43,21 @@ const actions = {
   save ({ dispatch }, config) {
     dispatch('task/saveSession', null, { root: true })
     if (isEmpty(config)) {
-      return
+      return Promise.resolve()
     }
 
     // Ensure payload is plain-serializable data (no Vue reactive proxies)
     const plainConfig = JSON.parse(JSON.stringify(config))
 
     dispatch('updatePreference', plainConfig)
-    return api.savePreference(plainConfig)
+    return api.savePreference(plainConfig).then((result) => {
+      if (result && result.ok === false) {
+        const err = new Error(result.message || 'save preference failed')
+        err.code = 1
+        throw err
+      }
+      return result
+    })
   },
   recordHistoryDirectory ({ state, dispatch }, directory) {
     const { historyDirectories = [], favoriteDirectories = [] } = state.config

--- a/src/shared/utils/index.js
+++ b/src/shared/utils/index.js
@@ -780,6 +780,16 @@ export const diffConfig = (current = {}, next = {}) => {
   return result
 }
 
+/** 比较 Tracker 源列表（忽略顺序与类型差异） */
+export const normalizeTrackerSourceList = (list = []) => {
+  return [...(list || [])].map((item) => String(item).trim()).filter(Boolean).sort()
+}
+
+export const isTrackerSourceListChanged = (current = [], next = []) => {
+  return JSON.stringify(normalizeTrackerSourceList(current)) !==
+    JSON.stringify(normalizeTrackerSourceList(next))
+}
+
 export const calcFormLabelWidth = (locale) => {
   return locale.startsWith('de') ? '28%' : '25%'
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

修复 #294 中报告的设置页保存无效问题。

### 问题现象
- 进阶设置修改 Tracker 服务器后，点击「保存并应用」无成功提示
- 2.0.1–2.0.5 多个版本持续反馈

### 修复内容
1. **表单校验链**：Advanced/Basic 改用 `Promise.resolve(formRef.validate())` 触发保存，避免 Element Plus 校验回调异常导致保存逻辑与提示均不执行
2. **Tracker 源检测**：新增 `normalizeTrackerSourceList` / `isTrackerSourceListChanged`，保存时可靠检测 trackerSource 变更
3. **IPC 保存确认**：偏好保存由 `ipcRenderer.send` 改为 `invoke('application:save-preference')`，主进程返回 `{ ok }`，渲染进程可感知失败并提示
4. **Basic 设置页**：补齐无变更提示、修正失败时误用 success 提示的问题

## Related Issues

Fixes #294

### Checklist:

* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran app with your changes locally?
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e6bf8ab-8abf-4eb8-b1f5-add515a0f2cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e6bf8ab-8abf-4eb8-b1f5-add515a0f2cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

