### PR TITLE
升级 pnpm 至 v11 并完成配置迁移

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ imFile 是一个基于 Electron + Vue 3 的全功能桌面下载管理器（Motr
 ### 开发环境要求
 
 - Node.js >= 24（通过 nvm 安装：`nvm install 24`）
-- pnpm（版本由 `package.json` 中 `packageManager` 字段指定，通过 corepack 自动管理）
+- pnpm 11（版本由 `package.json` 中 `packageManager` 字段指定，通过 corepack 自动管理；pnpm 配置位于 `pnpm-workspace.yaml`）
 - 显示服务器（Xvfb 已预装在 Cloud Agent VM，DISPLAY=:1）
 
 ### 常用命令

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "type": "git",
     "url": "https://github.com/imfile-io/imfile-desktop.git"
   },
-  "packageManager": "pnpm@10.34.5",
+  "packageManager": "pnpm@11.18.0",
   "scripts": {
     "release": "node .electron-vue/build.js && electron-builder --publish onTagOrDraft",
     "build": "node .electron-vue/build.js && electron-builder",
@@ -123,13 +123,5 @@
     "webpack-hot-middleware": "^2.26.1",
     "webpack-merge": "^6.0.1",
     "worker-loader": "^3.0.8"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "electron"
-    ],
-    "overrides": {
-      "punycode": "2.3.1"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,11 @@
+allowBuilds:
+  '@parcel/watcher': true
+  electron: true
+  electron-winstaller: true
+  unrs-resolver: true
+
+minimumReleaseAgeExclude:
+  - postcss
+
+overrides:
+  punycode: 2.3.1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

Renovate PR #359 尝试将 pnpm 从 10.34.5 升级到 11.18.0，但仅修改了 `packageManager` 字段，未完成 pnpm 11 所需的配置迁移，导致 CI 在 `pnpm install --frozen-lockfile` 阶段失败。

## 变更说明

### 配置迁移（pnpm 11 breaking change）

pnpm 11 不再读取 `package.json` 中的 `pnpm` 字段，相关配置已迁移至新建的 `pnpm-workspace.yaml`：

| 原配置 (package.json) | 新配置 (pnpm-workspace.yaml) |
|---|---|
| `pnpm.onlyBuiltDependencies: [electron]` | `allowBuilds`（含 electron 及 CI 所需的其他构建脚本包） |
| `pnpm.overrides.punycode` | `overrides.punycode` |

### allowBuilds 补充

pnpm 11 默认 `strictDepBuilds: true`，未声明允许的包无法执行 postinstall 脚本。除 `electron` 外，还允许了 CI/构建链路中实际需要的：

- `@parcel/watcher`（sass 文件监听）
- `electron-winstaller`（Windows 安装包构建）
- `unrs-resolver`（依赖解析原生模块）

### minimumReleaseAgeExclude

pnpm 11 默认启用 24 小时最短发布时间策略。master 锁文件中的 `postcss@8.5.25` 是近期 Renovate 合并的版本，会被策略拒绝。为 `postcss` 添加排除项，避免 CI 在 frozen-lockfile 安装时失败。

### 未重生成 lockfile

刻意保留现有 `pnpm-lock.yaml`，避免 pnpm 11 重新解析时引入无关依赖版本漂移（如 webpack 5.108.4 → 5.109.1）及 `blockExoticSubdeps` 导致的构建错误。

## 验证

- [x] `pnpm install --frozen-lockfile`（pnpm 11.18.0）
- [x] `pnpm run lint`
- [x] `pnpm run build:github`

## 关联

- 替代/修复 Renovate PR #359
- 合并后可关闭 #359

Made with [Cursor](https://cursor.com)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-caeaa1a2-c028-4916-b590-3784bb81a5c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-caeaa1a2-c028-4916-b590-3784bb81a5c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

