### PR TITLE
feat: 支持自定义下载完成命令（兼容 aria2 on-download-complete）

### DIFF
--- a/src/main/Application.js
+++ b/src/main/Application.js
@@ -15,6 +15,7 @@ import {
   PROXY_SCOPES
 } from '@shared/constants'
 import { checkIsNeedRun } from '@shared/utils'
+import { buildDownloadCompleteHookArgs } from '@shared/utils/downloadCompleteHook'
 import {
   convertTrackerDataToComma,
   fetchBtTrackerFromSource,
@@ -1242,6 +1243,50 @@ export default class Application extends EventEmitter {
     })
   }
 
+  /**
+   * 执行用户配置的下载完成钩子（兼容 aria2 --on-download-complete / --on-bt-download-complete）。
+   * 参数顺序：GID、文件数、文件路径。
+   */
+  runDownloadCompleteHook (task, fallbackPath, isBT) {
+    const key = isBT ? 'on-bt-download-complete' : 'on-download-complete'
+    const command = String(this.configManager.getUserConfig(key) || '').trim()
+    if (!command) {
+      return
+    }
+
+    const { gid, numFiles, filePath } = buildDownloadCompleteHookArgs(
+      task,
+      fallbackPath
+    )
+    if (!gid) {
+      return
+    }
+
+    logger.log(
+      '[imFile] download-complete hook:',
+      key,
+      command,
+      gid,
+      numFiles,
+      filePath
+    )
+
+    const spawnOpts = { detached: true, stdio: 'ignore' }
+    if (is.windows()) {
+      spawnOpts.windowsHide = true
+    }
+
+    try {
+      const child = spawn(command, [gid, numFiles, filePath], spawnOpts)
+      child.on('error', (err) => {
+        logger.warn('[imFile] download-complete hook error:', err.message)
+      })
+      child.unref()
+    } catch (err) {
+      logger.warn('[imFile] download-complete hook spawn failed:', err.message)
+    }
+  }
+
   sendCommand (command, ...args) {
     if (!this.emit(command, ...args)) {
       const window = this.windowManager.getFocusedWindow()
@@ -1617,13 +1662,16 @@ export default class Application extends EventEmitter {
       this.trayManager.handleSpeedChange(speed)
     })
 
-    this.on('task-download-complete', (task, path) => {
+    this.on('task-download-complete', (task, path, isBT) => {
       this.dockManager.openDock(path)
 
       if (is.linux()) {
-        return
+        // Linux 无 addRecentDocument，但仍需执行下载完成钩子
+      } else {
+        app.addRecentDocument(path)
       }
-      app.addRecentDocument(path)
+
+      this.runDownloadCompleteHook(task, path, isBT)
     })
 
     if (this.configManager.userConfig.get('show-progress-bar')) {

--- a/src/main/Application.js
+++ b/src/main/Application.js
@@ -1275,6 +1275,10 @@ export default class Application extends EventEmitter {
     }
 
     this.downloadCompleteHookFired.add(hookKey)
+    if (this.downloadCompleteHookFired.size > 5000) {
+      const recent = Array.from(this.downloadCompleteHookFired).slice(-2500)
+      this.downloadCompleteHookFired = new Set(recent)
+    }
 
     logger.log(
       '[imFile] download-complete hook:',

--- a/src/main/Application.js
+++ b/src/main/Application.js
@@ -16,6 +16,7 @@ import {
 } from '@shared/constants'
 import { checkIsNeedRun } from '@shared/utils'
 import { buildDownloadCompleteHookArgs } from '@shared/utils/downloadCompleteHook'
+import { spawnDownloadCompleteCommand } from './utils/downloadCompleteHookRunner'
 import {
   convertTrackerDataToComma,
   fetchBtTrackerFromSource,
@@ -62,6 +63,8 @@ export default class Application extends EventEmitter {
      * 用户确认执行 migrate-from-aria2 时为 true，用于显示迁移加载动画。
      */
     this._pendingLegacySessionMigrate = false
+    /** 已触发过下载完成钩子的 GID，避免重复执行 */
+    this.downloadCompleteHookFired = new Set()
     this.init()
   }
 
@@ -1248,6 +1251,15 @@ export default class Application extends EventEmitter {
    * 参数顺序：GID、文件数、文件路径。
    */
   runDownloadCompleteHook (task, fallbackPath, isBT) {
+    if (!task || !task.gid) {
+      return
+    }
+
+    const hookKey = `${isBT ? 'bt' : 'dl'}:${task.gid}`
+    if (this.downloadCompleteHookFired.has(hookKey)) {
+      return
+    }
+
     const key = isBT ? 'on-bt-download-complete' : 'on-download-complete'
     const command = String(this.configManager.getUserConfig(key) || '').trim()
     if (!command) {
@@ -1262,6 +1274,8 @@ export default class Application extends EventEmitter {
       return
     }
 
+    this.downloadCompleteHookFired.add(hookKey)
+
     logger.log(
       '[imFile] download-complete hook:',
       key,
@@ -1271,20 +1285,7 @@ export default class Application extends EventEmitter {
       filePath
     )
 
-    const spawnOpts = { detached: true, stdio: 'ignore' }
-    if (is.windows()) {
-      spawnOpts.windowsHide = true
-    }
-
-    try {
-      const child = spawn(command, [gid, numFiles, filePath], spawnOpts)
-      child.on('error', (err) => {
-        logger.warn('[imFile] download-complete hook error:', err.message)
-      })
-      child.unref()
-    } catch (err) {
-      logger.warn('[imFile] download-complete hook spawn failed:', err.message)
-    }
+    spawnDownloadCompleteCommand(command, gid, numFiles, filePath)
   }
 
   sendCommand (command, ...args) {
@@ -1431,6 +1432,7 @@ export default class Application extends EventEmitter {
     await this.stopEngine()
 
     app.clearRecentDocuments()
+    this.downloadCompleteHookFired.clear()
 
     const sessionPath = this.context.get('session-path')
     const goAria2SessionPath = this.context.get('go-aria2-session-path')
@@ -1665,13 +1667,11 @@ export default class Application extends EventEmitter {
     this.on('task-download-complete', (task, path, isBT) => {
       this.dockManager.openDock(path)
 
-      if (is.linux()) {
-        // Linux 无 addRecentDocument，但仍需执行下载完成钩子
-      } else {
+      if (!is.linux() && path) {
         app.addRecentDocument(path)
       }
 
-      this.runDownloadCompleteHook(task, path, isBT)
+      this.runDownloadCompleteHook(task, path, !!isBT)
     })
 
     if (this.configManager.userConfig.get('show-progress-bar')) {

--- a/src/main/core/ConfigManager.js
+++ b/src/main/core/ConfigManager.js
@@ -124,6 +124,8 @@ export default class ConfigManager {
         'log-level': 'warn',
         'new-task-show-downloading': true,
         'no-confirm-before-delete-task': false,
+        'on-bt-download-complete': EMPTY_STRING,
+        'on-download-complete': EMPTY_STRING,
         'open-at-login': false,
         protocols: { magnet: true, thunder: false, torrent: true, ed2k: false },
         proxy: {

--- a/src/main/utils/downloadCompleteHookRunner.js
+++ b/src/main/utils/downloadCompleteHookRunner.js
@@ -1,0 +1,36 @@
+import { spawn } from 'node:child_process'
+import is from 'electron-is'
+
+import logger from '../core/Logger'
+
+/**
+ * 启动下载完成钩子进程（跨平台处理 .bat/.cmd）。
+ * @returns {import('node:child_process').ChildProcess | null}
+ */
+export const spawnDownloadCompleteCommand = (command, gid, numFiles, filePath) => {
+  const args = [gid, numFiles, filePath]
+  const spawnOpts = { detached: true, stdio: 'ignore' }
+  if (is.windows()) {
+    spawnOpts.windowsHide = true
+  }
+
+  let executable = command
+  let spawnArgs = args
+
+  if (is.windows() && /\.(bat|cmd)$/i.test(command)) {
+    executable = process.env.comspec || 'cmd.exe'
+    spawnArgs = ['/d', '/s', '/c', command, ...args]
+  }
+
+  try {
+    const child = spawn(executable, spawnArgs, spawnOpts)
+    child.on('error', (err) => {
+      logger.warn('[imFile] download-complete hook error:', err.message)
+    })
+    child.unref()
+    return child
+  } catch (err) {
+    logger.warn('[imFile] download-complete hook spawn failed:', err.message)
+    return null
+  }
+}

--- a/src/renderer/components/Native/EngineClient.vue
+++ b/src/renderer/components/Native/EngineClient.vue
@@ -196,7 +196,7 @@ export default {
 
       const path = getTaskFullPath(task)
       this.showTaskCompleteNotify(task, isBT, path)
-      this.$electron.ipcRenderer.send('event', 'task-download-complete', task, path)
+      this.$electron.ipcRenderer.send('event', 'task-download-complete', task, path, isBT)
 
       this.$nextTick(() => {
         this.$store.dispatch('task/runPostDownloadActionIfIdle')

--- a/src/renderer/components/Native/EngineClient.vue
+++ b/src/renderer/components/Native/EngineClient.vue
@@ -30,6 +30,7 @@ import {
   showItemInFolder
 } from '@/utils/native'
 import { checkTaskIsBT, getTaskName } from '@shared/utils'
+import { adaptTaskForMainFlow } from '@/store/taskAdapter'
 import { POST_DOWNLOAD_ACTION } from '@shared/constants'
 
 const POST_DOWNLOAD_CONFIRM_SECONDS = 10
@@ -192,11 +193,22 @@ export default {
         })
     },
     handleDownloadComplete (task, isBT) {
+      const normalized = adaptTaskForMainFlow(task)
+      if (!normalized?.gid) {
+        return
+      }
+
       this.$store.dispatch('task/saveSession')
 
-      const path = getTaskFullPath(task)
-      this.showTaskCompleteNotify(task, isBT, path)
-      this.$electron.ipcRenderer.send('event', 'task-download-complete', task, path, isBT)
+      const path = getTaskFullPath(normalized)
+      this.showTaskCompleteNotify(normalized, isBT, path)
+      this.$electron.ipcRenderer.send(
+        'event',
+        'task-download-complete',
+        normalized,
+        path,
+        isBT
+      )
 
       this.$nextTick(() => {
         this.$store.dispatch('task/runPostDownloadActionIfIdle')

--- a/src/renderer/components/Preference/Advanced.vue
+++ b/src/renderer/components/Preference/Advanced.vue
@@ -459,6 +459,38 @@
             </el-button-group>
           </el-col>
         </el-form-item>
+        <el-form-item
+          :label="`${$t('preferences.on-download-complete')}: `"
+          :label-width="formLabelWidth"
+        >
+          <el-col class="form-item-sub" :span="24">
+            <el-input
+              v-model="form.onDownloadComplete"
+              clearable
+              :placeholder="$t('preferences.on-download-complete-placeholder')"
+              auto-complete="off"
+            />
+            <div class="el-form-item__info" style="margin-top: 8px;">
+              {{ $t('preferences.on-download-complete-hint') }}
+            </div>
+          </el-col>
+        </el-form-item>
+        <el-form-item
+          :label="`${$t('preferences.on-bt-download-complete')}: `"
+          :label-width="formLabelWidth"
+        >
+          <el-col class="form-item-sub" :span="24">
+            <el-input
+              v-model="form.onBtDownloadComplete"
+              clearable
+              :placeholder="$t('preferences.on-bt-download-complete-placeholder')"
+              auto-complete="off"
+            />
+            <div class="el-form-item__info" style="margin-top: 8px;">
+              {{ $t('preferences.on-bt-download-complete-hint') }}
+            </div>
+          </el-col>
+        </el-form-item>
         <!-- <el-form-item
           :label="`${$t('preferences.developer')}: `"
           :label-width="formLabelWidth"
@@ -587,6 +619,8 @@ const initForm = (config) => {
     lastSyncTrackerTime,
     listenPort,
     logLevel,
+    onBtDownloadComplete,
+    onDownloadComplete,
     protocols,
     proxy,
     rpcListenPort,
@@ -608,6 +642,8 @@ const initForm = (config) => {
     lastSyncTrackerTime,
     listenPort,
     logLevel,
+    onBtDownloadComplete: typeof onBtDownloadComplete === 'string' ? onBtDownloadComplete : '',
+    onDownloadComplete: typeof onDownloadComplete === 'string' ? onDownloadComplete : '',
     proxy: cloneDeep(proxy),
     protocols: {
       magnet: true,

--- a/src/renderer/store/modules/task.js
+++ b/src/renderer/store/modules/task.js
@@ -148,6 +148,7 @@ const actions = {
 
     for (const task of newlyCompleted) {
       dispatch('emitDownloadCompleteEvent', { task, isBT: false })
+      dispatch('runPostDownloadActionIfIdle')
     }
   },
   setOnCompleteAction ({ commit }, action) {

--- a/src/renderer/store/modules/task.js
+++ b/src/renderer/store/modules/task.js
@@ -2,6 +2,7 @@ import { ipcRenderer } from 'electron'
 import api from '@/api'
 import { EMPTY_STRING, POST_DOWNLOAD_ACTION, TASK_STATUS } from '@shared/constants'
 import { checkTaskIsBT, intersection, isTaskDownloading } from '@shared/utils'
+import { getTaskFullPath } from '@shared/utils/taskPath'
 import { adaptAria2Task, adaptGoed2kdTask } from '../taskAdapter'
 
 const resolveGoed2kdList = (resp) => {
@@ -56,6 +57,8 @@ const state = {
   currentTaskPeers: [],
   seedingList: [],
   taskList: [],
+  /** taskKey -> 上次轮询时的状态，用于检测 goed2kd 完成 */
+  taskStatusSnapshot: {},
   count: {
     downloading: 0,
     seeding: 0,
@@ -80,6 +83,9 @@ const mutations = {
   },
   UPDATE_TASK_LIST (state, taskList) {
     state.taskList = taskList
+  },
+  UPDATE_TASK_STATUS_SNAPSHOT (state, snapshot) {
+    state.taskStatusSnapshot = snapshot
   },
   UPDATE_SELECTED_TASK_KEY_LIST (state, taskKeyList) {
     state.selectedTaskKeyList = taskKeyList
@@ -111,6 +117,39 @@ const mutations = {
 }
 
 const actions = {
+  emitDownloadCompleteEvent (context, { task, isBT = false }) {
+    if (!task?.gid) {
+      return
+    }
+    const path = getTaskFullPath(task)
+    ipcRenderer.send('event', 'task-download-complete', task, path, !!isBT)
+  },
+  detectGoed2kdCompletedTasks ({ state, commit, dispatch }, taskList = []) {
+    const newlyCompleted = []
+    const nextSnapshot = { ...state.taskStatusSnapshot }
+
+    for (const task of taskList) {
+      if (task.engine !== 'goed2kd') {
+        continue
+      }
+      const key = task.taskKey
+      const prev = nextSnapshot[key]
+      if (
+        task.status === TASK_STATUS.COMPLETE &&
+        prev &&
+        prev !== TASK_STATUS.COMPLETE
+      ) {
+        newlyCompleted.push(task)
+      }
+      nextSnapshot[key] = task.status
+    }
+
+    commit('UPDATE_TASK_STATUS_SNAPSHOT', nextSnapshot)
+
+    for (const task of newlyCompleted) {
+      dispatch('emitDownloadCompleteEvent', { task, isBT: false })
+    }
+  },
   setOnCompleteAction ({ commit }, action) {
     commit('SET_ON_COMPLETE_ACTION', action)
   },
@@ -250,6 +289,7 @@ const actions = {
         }
 
         commit('UPDATE_TASK_LIST', taskList)
+        dispatch('detectGoed2kdCompletedTasks', taskList)
         if (listType !== 'all') {
           commit('UPDATE_COUNT', {
             ...state.count,
@@ -501,9 +541,12 @@ const actions = {
       console.warn('[imFile] saveSession failed:', err)
     })
   },
-  purgeTaskRecord ({ dispatch }) {
+  purgeTaskRecord ({ commit, dispatch }) {
     return api.purgeTaskRecord()
-      .finally(() => dispatch('fetchList'))
+      .finally(() => {
+        commit('UPDATE_TASK_STATUS_SNAPSHOT', {})
+        dispatch('fetchList')
+      })
   },
   toggleTask ({ dispatch }, task) {
     const { status } = task

--- a/src/renderer/store/taskAdapter.js
+++ b/src/renderer/store/taskAdapter.js
@@ -1,3 +1,5 @@
+import { dirname } from 'node:path'
+
 import { getTaskName, normalizeTaskStatus } from '@shared/utils'
 
 const toNumber = (value, defaultValue = 0) => {
@@ -33,6 +35,7 @@ export const adaptGoed2kdTask = (task = {}) => {
   const name = task.file_name || task.file_path || id
   const status = normalizeGoed2kdStatus(task.status || task.state)
   const filePath = task.file_path ? String(task.file_path) : ''
+  const downloadDir = filePath ? dirname(filePath) : ''
 
   return {
     ...task,
@@ -51,13 +54,13 @@ export const adaptGoed2kdTask = (task = {}) => {
     downloadSpeed: toNumber(task.download_rate, 0),
     progress,
     raw: task,
-    dir: filePath || '',
+    dir: downloadDir,
     bittorrent: null
   }
 }
 
 export const adaptTaskForMainFlow = (task = {}) => {
-  if (task.engine === 'goed2kd' || task.hash) {
+  if (task.engine === 'goed2kd') {
     return adaptGoed2kdTask(task)
   }
   return adaptAria2Task(task)

--- a/src/renderer/utils/native.js
+++ b/src/renderer/utils/native.js
@@ -4,9 +4,9 @@ import { shell, nativeTheme } from '@electron/remote'
 import { ElMessage as Message } from 'element-plus'
 
 import {
-  getFileNameFromFile,
   isMagnetTask
 } from '@shared/utils'
+import { getTaskFullPath as resolveTaskFullPath } from '@shared/utils/taskPath'
 import { APP_THEME, TASK_STATUS } from '@shared/constants'
 
 export const showItemInFolder = (fullPath, { errorMsg }) => {
@@ -35,42 +35,7 @@ export const openItem = async (fullPath) => {
   return result
 }
 
-export const getTaskFullPath = (task) => {
-  if (!task || typeof task !== 'object') {
-    return ''
-  }
-
-  const { dir, files, bittorrent } = task
-  const filesSafe = Array.isArray(files) ? files : []
-  let result = dir ? resolve(dir) : ''
-
-  // Magnet link task
-  if (isMagnetTask(task)) {
-    return result
-  }
-
-  if (bittorrent && bittorrent.info && bittorrent.info.name) {
-    result = resolve(result, bittorrent.info.name)
-    return result
-  }
-
-  const [file] = filesSafe
-  const path = file && file.path ? resolve(file.path) : ''
-  let fileName = ''
-
-  if (path) {
-    result = path
-  } else {
-    if (filesSafe.length === 1 && file) {
-      fileName = getFileNameFromFile(file)
-      if (fileName) {
-        result = resolve(result, fileName)
-      }
-    }
-  }
-
-  return result
-}
+export const getTaskFullPath = (task) => resolveTaskFullPath(task)
 
 export const moveTaskFilesToTrash = (task) => {
   /**

--- a/src/shared/configKeys.js
+++ b/src/shared/configKeys.js
@@ -20,6 +20,8 @@ const userKeys = [
   'log-level',
   'new-task-show-downloading',
   'no-confirm-before-delete-task',
+  'on-bt-download-complete',
+  'on-download-complete',
   'open-at-login',
   'protocols',
   'proxy',

--- a/src/shared/locales/en-US/preferences.js
+++ b/src/shared/locales/en-US/preferences.js
@@ -107,5 +107,11 @@ export default {
   'auto-check-update': 'Automatically check for updates',
   'last-check-update-time': 'Last checked for an update',
   'not-saved': 'Preferences not saved',
-  'not-saved-confirm': 'The modified preferences will be lost, are you sure you want to leave?'
+  'not-saved-confirm': 'The modified preferences will be lost, are you sure you want to leave?',
+  'on-download-complete': 'Command on download complete',
+  'on-download-complete-placeholder': '/path/to/script.sh',
+  'on-download-complete-hint': 'Same as aria2 --on-download-complete: run an executable or script after a download finishes. Arguments: GID, number of files, file path. Leave empty to disable.',
+  'on-bt-download-complete': 'Command on BT download complete',
+  'on-bt-download-complete-placeholder': '/path/to/bt-script.sh',
+  'on-bt-download-complete-hint': 'Same as aria2 --on-bt-download-complete: run before seeding starts after a BitTorrent download completes. Same argument format. Leave empty to disable.'
 }

--- a/src/shared/locales/en-US/preferences.js
+++ b/src/shared/locales/en-US/preferences.js
@@ -110,7 +110,7 @@ export default {
   'not-saved-confirm': 'The modified preferences will be lost, are you sure you want to leave?',
   'on-download-complete': 'Command on download complete',
   'on-download-complete-placeholder': '/path/to/script.sh',
-  'on-download-complete-hint': 'Same as aria2 --on-download-complete: run an executable or script after a download finishes. Arguments: GID, number of files, file path. Leave empty to disable.',
+  'on-download-complete-hint': 'Same as aria2 --on-download-complete: run an executable or script after a download finishes. Arguments: GID, number of files, file path. Works for HTTP, BT, ED2K, and other tasks. Leave empty to disable.',
   'on-bt-download-complete': 'Command on BT download complete',
   'on-bt-download-complete-placeholder': '/path/to/bt-script.sh',
   'on-bt-download-complete-hint': 'Same as aria2 --on-bt-download-complete: run before seeding starts after a BitTorrent download completes. Same argument format. Leave empty to disable.'

--- a/src/shared/locales/zh-CN/preferences.js
+++ b/src/shared/locales/zh-CN/preferences.js
@@ -109,5 +109,11 @@ export default {
   'follow-metalink': '自动开始下载磁力链接、种子内的文件',
   'follow-torrent': '种子下载完后自动下载种子内容',
   'not-saved': '设置未保存',
-  'not-saved-confirm': '已修改的设置将会丢失，确定要离开吗?'
+  'not-saved-confirm': '已修改的设置将会丢失，确定要离开吗?',
+  'on-download-complete': '下载完成时执行命令',
+  'on-download-complete-placeholder': '/path/to/script.sh',
+  'on-download-complete-hint': '与 aria2 的 --on-download-complete 相同：下载完成后执行可执行文件或脚本，参数依次为 GID、文件数、文件路径。留空则不执行。',
+  'on-bt-download-complete': 'BT 下载完成时执行命令',
+  'on-bt-download-complete-placeholder': '/path/to/bt-script.sh',
+  'on-bt-download-complete-hint': '与 aria2 的 --on-bt-download-complete 相同：BT 任务下载完成、开始做种前执行。参数格式同上。留空则不执行。'
 }

--- a/src/shared/locales/zh-CN/preferences.js
+++ b/src/shared/locales/zh-CN/preferences.js
@@ -112,7 +112,7 @@ export default {
   'not-saved-confirm': '已修改的设置将会丢失，确定要离开吗?',
   'on-download-complete': '下载完成时执行命令',
   'on-download-complete-placeholder': '/path/to/script.sh',
-  'on-download-complete-hint': '与 aria2 的 --on-download-complete 相同：下载完成后执行可执行文件或脚本，参数依次为 GID、文件数、文件路径。留空则不执行。',
+  'on-download-complete-hint': '与 aria2 的 --on-download-complete 相同：下载完成后执行可执行文件或脚本，参数依次为 GID、文件数、文件路径。适用于 HTTP/BT/ED2K 等任务。留空则不执行。',
   'on-bt-download-complete': 'BT 下载完成时执行命令',
   'on-bt-download-complete-placeholder': '/path/to/bt-script.sh',
   'on-bt-download-complete-hint': '与 aria2 的 --on-bt-download-complete 相同：BT 任务下载完成、开始做种前执行。参数格式同上。留空则不执行。'

--- a/src/shared/utils/downloadCompleteHook.js
+++ b/src/shared/utils/downloadCompleteHook.js
@@ -1,0 +1,36 @@
+import { resolve } from 'node:path'
+
+import { getFileNameFromFile, isTaskFileEntrySelected } from './index'
+
+/**
+ * 按 aria2 Event Hook 约定构造参数：GID、文件数、首个文件路径。
+ * @see https://aria2.github.io/manual/en/html/aria2c.html#event-hook
+ */
+export const buildDownloadCompleteHookArgs = (task = {}, fallbackPath = '') => {
+  const gid = String(task.gid || '')
+  const files = Array.isArray(task.files) ? task.files : []
+  const selectedFiles = files.filter((file) => isTaskFileEntrySelected(file))
+  const relevantFiles = selectedFiles.length > 0 ? selectedFiles : files
+  const numFiles = relevantFiles.length > 0
+    ? relevantFiles.length
+    : (fallbackPath ? 1 : 0)
+
+  let filePath = String(fallbackPath || '')
+  const first = relevantFiles[0]
+  if (first) {
+    if (first.path) {
+      filePath = resolve(String(first.path))
+    } else if (numFiles === 1) {
+      const name = getFileNameFromFile(first)
+      if (name && task.dir) {
+        filePath = resolve(String(task.dir), name)
+      }
+    }
+  }
+
+  return {
+    gid,
+    numFiles: String(Math.max(numFiles, 1)),
+    filePath
+  }
+}

--- a/src/shared/utils/downloadCompleteHook.js
+++ b/src/shared/utils/downloadCompleteHook.js
@@ -1,6 +1,14 @@
 import { resolve } from 'node:path'
 
-import { getFileNameFromFile, isTaskFileEntrySelected } from './index'
+import {
+  getFileNameFromFile,
+  isTaskFileEntrySelected
+} from './index'
+import { getTaskFullPath } from './taskPath'
+
+const hasFileSelectionMeta = (files = []) => {
+  return files.some((file) => file.selected != null || file.Selected != null)
+}
 
 /**
  * 按 aria2 Event Hook 约定构造参数：GID、文件数、首个文件路径。
@@ -10,19 +18,22 @@ export const buildDownloadCompleteHookArgs = (task = {}, fallbackPath = '') => {
   const gid = String(task.gid || '')
   const files = Array.isArray(task.files) ? task.files : []
   const selectedFiles = files.filter((file) => isTaskFileEntrySelected(file))
-  const relevantFiles = selectedFiles.length > 0 ? selectedFiles : files
-  const numFiles = relevantFiles.length > 0
-    ? relevantFiles.length
-    : (fallbackPath ? 1 : 0)
+  const relevantFiles = hasFileSelectionMeta(files) ? selectedFiles : files
+  const resolvedFallback = String(fallbackPath || getTaskFullPath(task) || '')
 
-  let filePath = String(fallbackPath || '')
+  let numFiles = relevantFiles.length
+  if (numFiles === 0 && resolvedFallback) {
+    numFiles = 1
+  }
+
+  let filePath = resolvedFallback
   const first = relevantFiles[0]
   if (first) {
     if (first.path) {
       filePath = resolve(String(first.path))
-    } else if (numFiles === 1) {
+    } else if (relevantFiles.length === 1 && task.dir) {
       const name = getFileNameFromFile(first)
-      if (name && task.dir) {
+      if (name) {
         filePath = resolve(String(task.dir), name)
       }
     }
@@ -30,7 +41,7 @@ export const buildDownloadCompleteHookArgs = (task = {}, fallbackPath = '') => {
 
   return {
     gid,
-    numFiles: String(Math.max(numFiles, 1)),
+    numFiles: String(numFiles),
     filePath
   }
 }

--- a/src/shared/utils/taskPath.js
+++ b/src/shared/utils/taskPath.js
@@ -1,0 +1,38 @@
+import { resolve } from 'node:path'
+
+import { getFileNameFromFile, isMagnetTask } from './index'
+
+/** 解析任务在磁盘上的主路径（与 renderer/utils/native 行为一致） */
+export const getTaskFullPath = (task) => {
+  if (!task || typeof task !== 'object') {
+    return ''
+  }
+
+  const { dir, files, bittorrent } = task
+  const filesSafe = Array.isArray(files) ? files : []
+  let result = dir ? resolve(dir) : ''
+
+  if (isMagnetTask(task)) {
+    return result
+  }
+
+  if (bittorrent && bittorrent.info && bittorrent.info.name) {
+    result = resolve(result, bittorrent.info.name)
+    return result
+  }
+
+  const [file] = filesSafe
+  const path = file && file.path ? resolve(file.path) : ''
+  let fileName = ''
+
+  if (path) {
+    result = path
+  } else if (filesSafe.length === 1 && file) {
+    fileName = getFileNameFromFile(file)
+    if (fileName) {
+      result = resolve(result, fileName)
+    }
+  }
+
+  return result
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

实现 Issue #340 请求的能力：在 imFile 中配置与 aria2 `--on-download-complete` / `--on-bt-download-complete` 等价的自定义命令。

## 变更说明

- **用户配置**：新增 `on-download-complete`、`on-bt-download-complete`，默认留空
- **UI**：偏好设置 → 进阶设置，增加两个命令输入框及中英文说明
- **执行逻辑**：主进程在下载完成事件中按 aria2 Event Hook 约定传递 `GID`、文件数、文件路径，并 detached 执行命令
- **引擎兼容**：由 imFile 应用层执行，不依赖 aria2c/go-aria2 是否原生支持 hook

## 审计修复（第二轮）

- **ED2K/goed2kd**：轮询检测任务状态变为 complete 时触发钩子
- **Windows**：`.bat`/`.cmd` 通过 `cmd.exe /c` 执行
- **numFiles**：修正全不选/无文件时的计数逻辑
- **BT 选择性下载**：正确区分「无 selected 元数据」与「全部未选」
- **路径解析**：抽取 `shared/utils/taskPath.js`，主进程与 UI 一致
- **去重**：同一 GID+事件类型仅执行一次；重置会话时清空
- **空任务防护**：`fetchTaskItem` 失败时不再误触发
- **goed2kd**：修正 `dir` 字段；完成时联动「下载完成后」全局动作

## 行为（与 aria2 一致）

| 事件 | 配置项 | 触发时机 |
|------|--------|----------|
| 普通下载完成 | `on-download-complete` | HTTP/FTP/磁力/ED2K 等，或 BT 做种结束后 |
| BT 下载完成 | `on-bt-download-complete` | BT 文件下载完成、开始做种前 |

## 使用示例

1. 打开 **偏好设置 → 进阶设置**
2. 在「下载完成时执行命令」填入脚本路径，例如 `/home/user/bin/on-complete.sh`
3. 脚本将收到三个参数：`$1=GID`、`$2=文件数`、`$3=文件路径`

```bash
#!/bin/bash
echo "GID=$1 files=$2 path=$3" >> /tmp/imfile-hook.log
```

## 相关 Issue

Closes #340
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82b648b4-29de-40a7-a867-0c17bbfc6726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82b648b4-29de-40a7-a867-0c17bbfc6726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

