### PR TITLE
chore(release): v2.1.1 — 升级 go-aria2 至 v0.1.1

### DIFF
--- a/ChangeLog-CN.md
+++ b/ChangeLog-CN.md
@@ -1,3 +1,4 @@
+- 升级 go-aria2 下载内核至 v0.1.1（addUri/addTorrent 支持 position 入队、getGlobalStat 增加 numStoppedTotal、新增 forceShutdown 别名等）
 - 任务页增加搜索入口并修复 Tab 与路由同步
 - 修复高级设置保存时校验回调导致无成功提示
 - BT 搜索支持分页翻页

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imFile",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A full-featured download manager",
   "homepage": "https://github.com/imfile-io/imfile-desktop",
   "author": {

--- a/scripts/sync-go-aria2.mjs
+++ b/scripts/sync-go-aria2.mjs
@@ -45,7 +45,13 @@ const FOLDER_TO_GO = {
   }
 }
 
-const API_LATEST = 'https://api.github.com/repos/chenjia404/go-aria2/releases/latest'
+/** 默认同步的 go-aria2 版本；可通过环境变量 GO_ARIA2_VERSION 覆盖（如 v0.1.1） */
+const GO_ARIA2_VERSION = process.env.GO_ARIA2_VERSION || 'v0.1.1'
+
+function releaseApiUrl (version) {
+  const tag = version.startsWith('v') ? version : `v${version}`
+  return `https://api.github.com/repos/chenjia404/go-aria2/releases/tags/${tag}`
+}
 
 function log (...args) {
   console.log('[sync-go-aria2]', ...args)
@@ -220,8 +226,8 @@ async function main () {
 
   log(`发现 ${targets.length} 个目标:`, targets.map((t) => `${t.platform}/${t.folderArch}`).join(', '))
 
-  const release = await fetchJson(API_LATEST)
-  log(`最新 Release: ${release.tag_name}`)
+  const release = await fetchJson(releaseApiUrl(GO_ARIA2_VERSION))
+  log(`同步 Release: ${release.tag_name}`)
 
   for (const t of targets) {
     await syncOne(t, release)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

发布 imFile **v2.1.1**，将内置下载内核 go-aria2 升级至上游 **v0.1.1**。

## 变更说明

### go-aria2 v0.1.1 主要更新
- `addUri` / `addTorrent` / `addMetalink` 支持 `position` 入队
- `getGlobalStat` 增加 `numStoppedTotal` 累计统计
- 新增 `aria2.forceShutdown` 别名

### 本仓库修改
- `scripts/sync-go-aria2.mjs`：默认固定同步 `v0.1.1`（可通过环境变量 `GO_ARIA2_VERSION` 覆盖）
- `package.json`：版本号 `2.1.0` → `2.1.1`
- `ChangeLog-CN.md`：补充升级说明

## 发布步骤

合并后打 tag `v2.1.1` 即可触发 CI 自动构建发布；构建流程会执行 `pnpm run sync-go-aria2` 拉取 go-aria2 v0.1.1 二进制。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c02078a-4fa7-4858-a177-aeec8ef0d261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c02078a-4fa7-4858-a177-aeec8ef0d261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

