### PR TITLE
升级 go-aria2 下载内核至 v0.2.1

### DIFF
--- a/ChangeLog-CN.md
+++ b/ChangeLog-CN.md
@@ -1,3 +1,4 @@
+- 升级 go-aria2 下载内核至 v0.2.1（FTP/SFTP 限速与热更新、ED2K 迁移至 goed2k/core、补齐 saveSession/removeDownloadResult 等 RPC、修复 bt-max-peers 热更新等）
 - 升级 go-aria2 下载内核至 v0.1.1（addUri/addTorrent 支持 position 入队、getGlobalStat 增加 numStoppedTotal、新增 forceShutdown 别名等）
 - 任务页增加搜索入口并修复 Tab 与路由同步
 - 修复高级设置保存时校验回调导致无成功提示

--- a/scripts/sync-go-aria2.mjs
+++ b/scripts/sync-go-aria2.mjs
@@ -45,8 +45,8 @@ const FOLDER_TO_GO = {
   }
 }
 
-/** 默认同步的 go-aria2 版本；可通过环境变量 GO_ARIA2_VERSION 覆盖（如 v0.1.1） */
-const GO_ARIA2_VERSION = process.env.GO_ARIA2_VERSION || 'v0.1.1'
+/** 默认同步的 go-aria2 版本；可通过环境变量 GO_ARIA2_VERSION 覆盖（如 v0.2.1） */
+const GO_ARIA2_VERSION = process.env.GO_ARIA2_VERSION || 'v0.2.1'
 
 function releaseApiUrl (version) {
   const tag = version.startsWith('v') ? version : `v${version}`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

将 `scripts/sync-go-aria2.mjs` 默认同步版本从 **v0.1.1** 提升至 **v0.2.1**（上游最新稳定版），并更新 `ChangeLog-CN.md`。

### 验证情况

在 Linux x64 环境下，按 imFile `Engine.js` 的启动参数（`--conf-path`、`--save-session`、`--data-dir` 等）实测 v0.2.1：

- 核心 RPC 正常：`getVersion`、`getGlobalStat`、`tellActive/Waiting/Stopped`、`addUri`、`pause/unpause/remove`、`changeOption`、`system.multicall` 等
- v0.2.1 已补齐此前需 fallback 的接口：`saveSession`、`removeDownloadResult`、`purgeDownloadResult`、`forcePauseAll`、`forceShutdown`
- `migrate-from-aria2` 旧会话迁移流程正常
- `session.json` 持久化正常

### v0.2.1 主要变更（上游）

- FTP/SFTP 下载速度追踪、任务级与全局限速、`changeGlobalOption` 热更新
- ED2K 底层库迁移至 goed2k/core v0.1.2
- 修复 `bt-max-peers` 选项热更新语义
- 更多 aria2 RPC 兼容性对齐

### 已知限制（与 v0.1.1 相同）

- `win32/ia32` 仍无上游 Release 资源，同步脚本会跳过该架构
- `aria2.tellDone` 未实现，但 imFile 当前未调用 `fetchDoneTaskList`，不影响使用

### Checklist

* [x] 已确认无重复 PR
* [x] 相关单元测试通过（`pnpm run test`）
* [x] 已在本地对 go-aria2 v0.2.1 二进制做 RPC 兼容性验证

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68b1cdda-7822-4c67-8ad4-4c7f72803cf4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68b1cdda-7822-4c67-8ad4-4c7f72803cf4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

