### PR TITLE
fix(portable): 便携模式启动后清理 AppData 下的空 imFile 目录

### DIFF
--- a/src/main/portable-userdata.js
+++ b/src/main/portable-userdata.js
@@ -6,7 +6,7 @@
  * 2. 环境变量 IMFILE_PORTABLE=1 或命令行 --portable
  * 3. Windows ZIP 解压版：exe 旁有 resources/app.asar 且无 NSIS 卸载程序
  */
-import { cpSync, existsSync, readdirSync } from 'node:fs'
+import { cpSync, existsSync, readdirSync, rmdirSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { app } from 'electron'
 
@@ -106,6 +106,23 @@ function migrateLegacyUserDataIfNeeded (legacyDir, portableRoot) {
   }
 }
 
+/**
+ * 便携模式会先调用 app.getPath('userData') 解析默认路径，Electron 会创建该目录。
+ * 重定向到程序目录后，若 AppData 下仅剩空目录则删除，避免残留空的 %APPDATA%\\imFile。
+ */
+function removeEmptyLegacyUserDataDir (legacyDir) {
+  if (!legacyDir) {
+    return
+  }
+  try {
+    if (existsSync(legacyDir) && readdirSync(legacyDir).length === 0) {
+      rmdirSync(legacyDir)
+    }
+  } catch (err) {
+    console.warn('[imFile] 便携模式：清理 AppData 空目录失败', err)
+  }
+}
+
 function resolvePortableRoot () {
   const envDir = process.env.PORTABLE_EXECUTABLE_DIR
   if (typeof envDir === 'string' && envDir.length > 0) {
@@ -137,4 +154,5 @@ if (portableRoot) {
   app.setPath('userData', portableRoot)
   app.setPath('logs', join(portableRoot, 'logs'))
   app.setPath('cache', getPortableCacheDir(portableRoot))
+  removeEmptyLegacyUserDataDir(defaultUserData)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

便携版 / ZIP 解压版在初始化时会先调用 `app.getPath('userData')` 以获取默认的 `%APPDATA%\imFile` 路径，Electron 会因此创建该目录。随后应用将 `userData` 重定向到程序目录，但 AppData 下的空 `imFile` 文件夹仍会残留。

本 PR 在便携模式完成路径重定向后，检测 legacy `userData` 目录是否为空；若为空则删除，避免在 Roaming 下留下无用空目录。

**安全策略**：仅删除完全为空的目录。若旧用户 AppData 中仍有 `logs`、`Cache` 等未迁移内容，目录不会被删除。

## Related Issues

Fixes #407

### Checklist:

* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran app with your changes locally?
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0636a32-f66d-4498-b78f-02d7340265ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0636a32-f66d-4498-b78f-02d7340265ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

