### PR TITLE
feat(task): 恢复新建任务对话框中的分片数设置

### DIFF
--- a/src/renderer/components/Task/AddTask.vue
+++ b/src/renderer/components/Task/AddTask.vue
@@ -277,7 +277,7 @@ export default {
 
       if (current === ADD_TASK_TYPE.URI) {
         setTimeout(() => {
-          this.$refs.uri && this.$refs.uri.focus()
+          this.$refs.uri?.focus?.()
         }, 50)
       }
     },
@@ -312,7 +312,7 @@ export default {
       if (this.taskType === ADD_TASK_TYPE.URI) {
         this.autofillResourceLink()
         setTimeout(() => {
-          this.$refs.uri && this.$refs.uri.focus()
+          this.$refs.uri?.focus?.()
         }, 50)
       }
     },

--- a/src/renderer/components/Task/AddTask.vue
+++ b/src/renderer/components/Task/AddTask.vue
@@ -36,7 +36,7 @@
         </el-tab-pane>
       </el-tabs>
       <el-row :gutter="12">
-        <el-col :span="24" :xs="24">
+        <el-col :span="15" :xs="24">
           <el-form-item
             :label="`${$t('task.task-out')}: `"
             :label-width="formLabelWidth"
@@ -48,7 +48,7 @@
             </el-input>
           </el-form-item>
         </el-col>
-        <!-- <el-col :span="9" :xs="24">
+        <el-col :span="9" :xs="24">
           <el-form-item
             :label="`${$t('task.task-split')}: `"
             :label-width="formLabelWidth"
@@ -62,7 +62,7 @@
             >
             </el-input-number>
           </el-form-item>
-        </el-col> -->
+        </el-col>
       </el-row>
       <el-form-item
         :label="`${$t('task.task-dir')}: `"

--- a/src/renderer/components/Task/AddTask.vue
+++ b/src/renderer/components/Task/AddTask.vue
@@ -57,7 +57,7 @@
               v-model="form.split"
               controls-position="right"
               :min="1"
-              :max="config.engineMaxConnectionPerServer"
+              :max="splitMax"
               :label="$t('task.task-split')"
             >
             </el-input-number>
@@ -215,7 +215,7 @@ import {
   buildUriPayload,
   buildTorrentPayload
 } from '@/utils/task'
-import { ADD_TASK_TYPE } from '@shared/constants'
+import { ADD_TASK_TYPE, ENGINE_MAX_CONNECTION_PER_SERVER } from '@shared/constants'
 import { detectResource } from '@shared/utils'
 import { Close } from '@element-plus/icons-vue'
 import '@/components/Icons/inbox'
@@ -264,6 +264,9 @@ export default {
     },
     dialogTop () {
       return this.showAdvanced ? '8vh' : '15vh'
+    },
+    splitMax () {
+      return this.config.engineMaxConnectionPerServer || ENGINE_MAX_CONNECTION_PER_SERVER
     }
   },
   watch: {

--- a/src/renderer/utils/task.js
+++ b/src/renderer/utils/task.js
@@ -2,6 +2,7 @@ import { isEmpty } from 'lodash'
 
 import {
   ADD_TASK_TYPE,
+  ENGINE_MAX_CONNECTION_PER_SERVER,
   NONE_SELECTED_FILES,
   SELECTED_ALL_FILES
 } from '@shared/constants'
@@ -13,6 +14,28 @@ import {
   buildHeadersFromCurl,
   buildDefaultOptionsFromCurl
 } from '@shared/utils/curl'
+
+export const resolveTaskSplit = ({
+  split = 0,
+  maxConnectionPerServer = 0,
+  engineMaxConnectionPerServer = ENGINE_MAX_CONNECTION_PER_SERVER
+} = {}) => {
+  const engineMax = engineMaxConnectionPerServer || ENGINE_MAX_CONNECTION_PER_SERVER
+  const preferred = split > 0 ? split : maxConnectionPerServer
+  const cappedByPreference = maxConnectionPerServer > 0
+    ? Math.min(preferred, maxConnectionPerServer)
+    : preferred
+
+  return Math.min(Math.max(1, cappedByPreference || 1), engineMax)
+}
+
+export const clampTaskSplit = (
+  value,
+  engineMaxConnectionPerServer = ENGINE_MAX_CONNECTION_PER_SERVER
+) => {
+  const engineMax = engineMaxConnectionPerServer || ENGINE_MAX_CONNECTION_PER_SERVER
+  return Math.min(Math.max(1, value || 1), engineMax)
+}
 
 export const initTaskForm = state => {
   const { addTaskUrl, addTaskOptions } = state.app
@@ -38,12 +61,19 @@ export const initTaskForm = state => {
     out: '',
     referer: '',
     selectFile: NONE_SELECTED_FILES,
-    split,
+    split: resolveTaskSplit({
+      split,
+      maxConnectionPerServer,
+      engineMaxConnectionPerServer
+    }),
     torrent: '',
     uris: addTaskUrl,
     userAgent: '',
     authorization: '',
     ...addTaskOptions
+  }
+  if ('split' in addTaskOptions) {
+    result.split = clampTaskSplit(addTaskOptions.split, engineMaxConnectionPerServer)
   }
   return result
 }

--- a/tests/helpers/vue-test-helpers.js
+++ b/tests/helpers/vue-test-helpers.js
@@ -170,7 +170,12 @@ export const elementPlusStubs = {
   'el-form-item': { template: '<div class="el-form-item"><slot /></div>' },
   'el-tabs': { template: '<div class="el-tabs"><slot /></div>', props: ['modelValue'] },
   'el-tab-pane': { template: '<div class="el-tab-pane"><slot /></div>', props: ['name', 'label'] },
-  'el-input': { template: '<input class="el-input" />' },
+  'el-input': {
+    template: '<input class="el-input" />',
+    methods: {
+      focus () {}
+    }
+  },
   'el-button': { template: '<button class="el-button"><slot /></button>' },
   'el-row': { template: '<div class="el-row"><slot /></div>' },
   'el-col': { template: '<div class="el-col"><slot /></div>', props: ['span'] },

--- a/tests/renderer/components/Task/AddTask.test.js
+++ b/tests/renderer/components/Task/AddTask.test.js
@@ -94,6 +94,23 @@ describe('AddTask', () => {
     expect(dispatchSpy).toHaveBeenCalledWith('app/updateAddTaskOptions', {})
   })
 
+  it('打开对话框时初始化分片数表单字段', async () => {
+    const { wrapper } = mountAddTask()
+    wrapper.vm.handleOpen()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.form.split).toBe(16)
+  })
+
+  it('显示分片数输入控件', async () => {
+    const { wrapper } = mountAddTask()
+    wrapper.vm.handleOpen()
+    await wrapper.vm.$nextTick()
+
+    const splitInput = wrapper.find('.el-input-number')
+    expect(splitInput.exists()).toBe(true)
+  })
+
   it('选择目录时写入表单并记录历史', () => {
     const { wrapper, store } = mountAddTask()
     const dispatchSpy = vi.spyOn(store, 'dispatch')

--- a/tests/renderer/components/Task/AddTask.test.js
+++ b/tests/renderer/components/Task/AddTask.test.js
@@ -111,6 +111,23 @@ describe('AddTask', () => {
     expect(splitInput.exists()).toBe(true)
   })
 
+  it('提交任务时携带自定义分片数', async () => {
+    const { wrapper, store } = mountAddTask()
+    const dispatchSpy = vi.spyOn(store, 'dispatch')
+
+    wrapper.vm.handleOpen()
+    wrapper.vm.form.uris = 'https://example.com/file.zip'
+    wrapper.vm.form.split = 2
+    await wrapper.vm.submitForm('taskForm')
+
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'task/addUri',
+      expect.objectContaining({
+        options: expect.objectContaining({ split: 2 })
+      })
+    )
+  })
+
   it('选择目录时写入表单并记录历史', () => {
     const { wrapper, store } = mountAddTask()
     const dispatchSpy = vi.spyOn(store, 'dispatch')

--- a/tests/renderer/components/Task/AddTask.test.js
+++ b/tests/renderer/components/Task/AddTask.test.js
@@ -1,5 +1,5 @@
 import { shallowMount } from '@vue/test-utils'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ADD_TASK_TYPE } from '@shared/constants'
 import {
@@ -32,6 +32,19 @@ vi.mock('@/components/Icons/inbox', () => ({}))
 const { default: AddTask } = await import('@/components/Task/AddTask.vue')
 
 describe('AddTask', () => {
+  beforeEach(() => {
+    vi.stubGlobal('navigator', {
+      clipboard: {
+        readText: vi.fn(() => Promise.resolve(''))
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
   const mountAddTask = (props = {}) => {
     const store = createTestStore()
     const msg = vi.fn()
@@ -95,16 +108,20 @@ describe('AddTask', () => {
   })
 
   it('打开对话框时初始化分片数表单字段', async () => {
+    vi.useFakeTimers()
     const { wrapper } = mountAddTask()
     wrapper.vm.handleOpen()
+    await vi.runAllTimersAsync()
     await wrapper.vm.$nextTick()
 
     expect(wrapper.vm.form.split).toBe(16)
   })
 
   it('显示分片数输入控件', async () => {
+    vi.useFakeTimers()
     const { wrapper } = mountAddTask()
     wrapper.vm.handleOpen()
+    await vi.runAllTimersAsync()
     await wrapper.vm.$nextTick()
 
     const splitInput = wrapper.find('.el-input-number')
@@ -112,10 +129,12 @@ describe('AddTask', () => {
   })
 
   it('提交任务时携带自定义分片数', async () => {
+    vi.useFakeTimers()
     const { wrapper, store } = mountAddTask()
     const dispatchSpy = vi.spyOn(store, 'dispatch')
 
     wrapper.vm.handleOpen()
+    await vi.runAllTimersAsync()
     wrapper.vm.form.uris = 'https://example.com/file.zip'
     wrapper.vm.form.split = 2
     await wrapper.vm.submitForm('taskForm')

--- a/tests/renderer/utils/task.test.js
+++ b/tests/renderer/utils/task.test.js
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { ADD_TASK_TYPE } from '@shared/constants'
+import {
+  buildOption,
+  buildUriPayload,
+  initTaskForm
+} from '@/utils/task'
+import { createTestStore } from '../../helpers/vue-test-helpers.js'
+
+describe('renderer/utils/task', () => {
+  it('initTaskForm 包含分片数默认值', () => {
+    const store = createTestStore()
+    const form = initTaskForm(store.state)
+
+    expect(form.split).toBe(16)
+    expect(form.engineMaxConnectionPerServer).toBe(64)
+  })
+
+  it('buildOption 在 split > 0 时写入 split', () => {
+    const options = buildOption(ADD_TASK_TYPE.URI, {
+      allProxy: '',
+      dir: '/downloads',
+      out: '',
+      selectFile: '',
+      split: 2
+    })
+
+    expect(options.split).toBe(2)
+  })
+
+  it('buildOption 在 split 未设置时不写入 split', () => {
+    const options = buildOption(ADD_TASK_TYPE.URI, {
+      allProxy: '',
+      dir: '/downloads',
+      out: '',
+      selectFile: '',
+      split: 0
+    })
+
+    expect(options.split).toBeUndefined()
+  })
+
+  it('buildUriPayload 携带自定义分片数', () => {
+    const payload = buildUriPayload({
+      uris: 'https://example.com/file.zip',
+      out: '',
+      allProxy: '',
+      dir: '/downloads',
+      selectFile: '',
+      split: 1,
+      userAgent: '',
+      referer: '',
+      cookie: '',
+      authorization: ''
+    })
+
+    expect(payload.options.split).toBe(1)
+  })
+})

--- a/tests/renderer/utils/task.test.js
+++ b/tests/renderer/utils/task.test.js
@@ -3,8 +3,11 @@ import { describe, expect, it } from 'vitest'
 import { ADD_TASK_TYPE } from '@shared/constants'
 import {
   buildOption,
+  buildTorrentPayload,
   buildUriPayload,
-  initTaskForm
+  clampTaskSplit,
+  initTaskForm,
+  resolveTaskSplit
 } from '@/utils/task'
 import { createTestStore } from '../../helpers/vue-test-helpers.js'
 
@@ -15,6 +18,39 @@ describe('renderer/utils/task', () => {
 
     expect(form.split).toBe(16)
     expect(form.engineMaxConnectionPerServer).toBe(64)
+  })
+
+  it('resolveTaskSplit 将系统 split 限制在 maxConnectionPerServer 内', () => {
+    expect(resolveTaskSplit({
+      split: 64,
+      maxConnectionPerServer: 8,
+      engineMaxConnectionPerServer: 64
+    })).toBe(8)
+  })
+
+  it('resolveTaskSplit 在无 maxConnectionPerServer 时使用 split', () => {
+    expect(resolveTaskSplit({
+      split: 32,
+      maxConnectionPerServer: 0,
+      engineMaxConnectionPerServer: 64
+    })).toBe(32)
+  })
+
+  it('clampTaskSplit 允许显式覆盖高于偏好上限的值', () => {
+    expect(clampTaskSplit(32, 64)).toBe(32)
+    expect(clampTaskSplit(0, 64)).toBe(1)
+    expect(clampTaskSplit(128, 64)).toBe(64)
+  })
+
+  it('initTaskForm 保留 addTaskOptions 中的显式分片数', () => {
+    const store = createTestStore({
+      appState: {
+        addTaskOptions: { split: 2 }
+      }
+    })
+    const form = initTaskForm(store.state)
+
+    expect(form.split).toBe(2)
   })
 
   it('buildOption 在 split > 0 时写入 split', () => {
@@ -56,5 +92,22 @@ describe('renderer/utils/task', () => {
     })
 
     expect(payload.options.split).toBe(1)
+  })
+
+  it('buildTorrentPayload 携带自定义分片数', () => {
+    const payload = buildTorrentPayload({
+      torrent: 'base64-torrent',
+      allProxy: '',
+      dir: '/downloads',
+      out: '',
+      selectFile: '',
+      split: 2,
+      userAgent: '',
+      referer: '',
+      cookie: '',
+      authorization: ''
+    })
+
+    expect(payload.options.split).toBe(2)
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

在「新建任务」对话框中恢复分片数（连接数）设置选项，与 Motrix 行为一致。

imFile fork 时该 UI 被注释隐藏，但底层逻辑（`initTaskForm`、`buildOption`）一直保留。本次改动恢复界面，并经过自审加固：

- 「重命名」与「分片数」并排显示（15/9 栅格布局）
- 分片数范围 1 ~ `engineMaxConnectionPerServer`，默认值按偏好设置收敛
- 提交任务时通过 `buildOption` 将 `split` 传递给 aria2 引擎
- 新增 `resolveTaskSplit` / `clampTaskSplit`，避免系统默认 split（64）高于用户偏好上限时显示不合理默认值
- `addTaskOptions` 显式传入的 split 允许单任务覆盖偏好上限（仅受引擎硬上限约束）

## Related Issues

Fixes #154

### Checklist:

* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?（单元测试与 lint 已通过，Bugbot 审计无问题）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b608a53a-a8ea-4201-b59f-2cf2e1bce9ac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b608a53a-a8ea-4201-b59f-2cf2e1bce9ac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

