### PR TITLE
test: 补充第二批 taskAdapter 与 Goed2kdClient 单元测试

### DIFF
--- a/tests/main/core/Goed2kdClient.test.js
+++ b/tests/main/core/Goed2kdClient.test.js
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const VALID_HASH = '0123456789abcdef0123456789abcdef01234567'
+
+function createJsonResponse (payload, { ok = true, status = 200 } = {}) {
+  return {
+    ok,
+    status,
+    json: vi.fn().mockResolvedValue(payload)
+  }
+}
+
+describe('Goed2kdClient', () => {
+  let fetchMock
+  let Goed2kdClient
+  let client
+
+  beforeEach(async () => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    vi.resetModules()
+
+    const mod = await import('../../../src/main/core/Goed2kdClient.js')
+    Goed2kdClient = mod.default
+    client = new Goed2kdClient({
+      getRuntimeOptions: () => ({
+        host: '10.0.0.2',
+        port: 19090,
+        token: 'secret-token'
+      })
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  it('getBaseUrl 使用运行时 host/port', () => {
+    expect(client.getBaseUrl()).toBe('http://10.0.0.2:19090/api/v1')
+  })
+
+  it('getBaseUrl 在无运行时配置时使用默认值', async () => {
+    const { default: Goed2kdClientClass } = await import('../../../src/main/core/Goed2kdClient.js')
+    const defaultClient = new Goed2kdClientClass()
+    expect(defaultClient.getBaseUrl()).toBe('http://127.0.0.1:18080/api/v1')
+  })
+
+  it('getAuthHeader 有 token 时返回 Bearer', () => {
+    expect(client.getAuthHeader()).toEqual({
+      Authorization: 'Bearer secret-token'
+    })
+  })
+
+  it('getAuthHeader 无 token 时返回空对象', async () => {
+    const { default: Goed2kdClientClass } = await import('../../../src/main/core/Goed2kdClient.js')
+    const noTokenClient = new Goed2kdClientClass()
+    expect(noTokenClient.getAuthHeader()).toEqual({})
+  })
+
+  it('request 成功时返回 data 字段', async () => {
+    fetchMock.mockResolvedValue(createJsonResponse({
+      code: 'OK',
+      data: [{ hash: VALID_HASH }]
+    }))
+
+    const data = await client.listTransfers()
+    expect(data).toEqual([{ hash: VALID_HASH }])
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://10.0.0.2:19090/api/v1/transfers',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer secret-token'
+        })
+      })
+    )
+  })
+
+  it('request 在 HTTP 非 2xx 时抛出错误', async () => {
+    fetchMock.mockResolvedValue(createJsonResponse({
+      code: 'ERR',
+      message: 'bad gateway'
+    }, { ok: false, status: 502 }))
+
+    await expect(client.listTransfers()).rejects.toThrow('bad gateway')
+  })
+
+  it('request 在响应体 code 非 OK 时抛出错误', async () => {
+    fetchMock.mockResolvedValue(createJsonResponse({
+      code: 'INVALID_QUERY',
+      message: 'query required'
+    }))
+
+    await expect(client.startSearch({ query: '' })).rejects.toThrow('query required')
+  })
+
+  it('request 在 JSON 解析失败时使用 BAD_RESPONSE', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockRejectedValue(new Error('Unexpected token'))
+    })
+
+    await expect(client.listTransfers()).rejects.toThrow('Unexpected token')
+  })
+
+  it('addEd2k 提交 ed2k 链接', async () => {
+    fetchMock.mockResolvedValue(createJsonResponse({ code: 'OK', data: { hash: VALID_HASH } }))
+    const ed2k = 'ed2k://|file|a.mkv|1|ABCDEF0123456789ABCDEF0123456789|/'
+
+    await client.addEd2k(ed2k)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://10.0.0.2:19090/api/v1/transfers',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ ed2k_link: ed2k })
+      })
+    )
+  })
+
+  it('pauseTransfer / resumeTransfer / removeTransfer 调用对应端点', async () => {
+    fetchMock.mockResolvedValue(createJsonResponse({ code: 'OK', data: null }))
+
+    await client.pauseTransfer(VALID_HASH)
+    await client.resumeTransfer(VALID_HASH)
+    await client.removeTransfer(VALID_HASH)
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      `http://10.0.0.2:19090/api/v1/transfers/${VALID_HASH}/pause`,
+      expect.objectContaining({ method: 'POST' })
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      `http://10.0.0.2:19090/api/v1/transfers/${VALID_HASH}/resume`,
+      expect.objectContaining({ method: 'POST' })
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      `http://10.0.0.2:19090/api/v1/transfers/${VALID_HASH}`,
+      expect.objectContaining({ method: 'DELETE' })
+    )
+  })
+
+  it('startSearch 填充默认查询参数', async () => {
+    fetchMock.mockResolvedValue(createJsonResponse({ code: 'OK', data: { state: 'RUNNING' } }))
+
+    await client.startSearch({ query: 'movie' })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://10.0.0.2:19090/api/v1/searches',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          query: 'movie',
+          scope: 'all',
+          min_size: 0,
+          max_size: 0,
+          min_sources: 0,
+          min_complete_sources: 0,
+          file_type: '',
+          extension: ''
+        })
+      })
+    )
+  })
+
+  it('getCurrentSearch 与 stopSearch 调用正确路径', async () => {
+    fetchMock.mockResolvedValue(createJsonResponse({ code: 'OK', data: null }))
+
+    await client.getCurrentSearch()
+    await client.stopSearch()
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'http://10.0.0.2:19090/api/v1/searches/current',
+      expect.objectContaining({ method: 'GET' })
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'http://10.0.0.2:19090/api/v1/searches/current/stop',
+      expect.objectContaining({ method: 'POST' })
+    )
+  })
+
+  it('downloadSearchResult 编码 hash 并传递可选字段', async () => {
+    fetchMock.mockResolvedValue(createJsonResponse({ code: 'OK', data: { ok: true } }))
+    const hashWithSlash = 'ab/cd'
+
+    await client.downloadSearchResult(hashWithSlash, {
+      target_dir: '/downloads',
+      target_name: 'movie.mkv',
+      paused: true
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `http://10.0.0.2:19090/api/v1/searches/current/results/${encodeURIComponent(hashWithSlash)}/download`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          target_dir: '/downloads',
+          target_name: 'movie.mkv',
+          paused: true
+        })
+      })
+    )
+  })
+
+  it('getNetworkDht 请求网络 DHT 状态', async () => {
+    fetchMock.mockResolvedValue(createJsonResponse({
+      code: 'OK',
+      data: { enabled: true }
+    }))
+
+    const data = await client.getNetworkDht()
+    expect(data).toEqual({ enabled: true })
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://10.0.0.2:19090/api/v1/network/dht',
+      expect.objectContaining({ method: 'GET' })
+    )
+  })
+})

--- a/tests/renderer/store/taskAdapter.test.js
+++ b/tests/renderer/store/taskAdapter.test.js
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest'
+
+import { TASK_STATUS } from '@shared/constants'
+import {
+  adaptAria2Task,
+  adaptGoed2kdTask,
+  adaptTaskForMainFlow,
+  buildTaskKey,
+  getTaskDisplayName
+} from '@/store/taskAdapter'
+
+const VALID_HASH = '0123456789abcdef0123456789abcdef01234567'
+
+describe('buildTaskKey', () => {
+  it('拼接 engine 与 id', () => {
+    expect(buildTaskKey('aria2', 'abc')).toBe('aria2:abc')
+    expect(buildTaskKey('goed2kd', VALID_HASH)).toBe(`goed2kd:${VALID_HASH}`)
+  })
+})
+
+describe('adaptAria2Task', () => {
+  it('规范化 aria2 任务字段', () => {
+    const raw = {
+      gid: 'aria2-gid-1',
+      status: 'downloading',
+      totalLength: '1024',
+      completedLength: '512'
+    }
+    const task = adaptAria2Task(raw)
+
+    expect(task).toMatchObject({
+      engine: 'aria2',
+      id: 'aria2-gid-1',
+      gid: 'aria2-gid-1',
+      status: TASK_STATUS.ACTIVE,
+      taskKey: 'aria2:aria2-gid-1',
+      totalLength: '1024',
+      completedLength: '512'
+    })
+    expect(task.raw).toBe(raw)
+  })
+
+  it('缺少 gid 时 id 为空字符串', () => {
+    const task = adaptAria2Task({ status: 'waiting' })
+    expect(task.id).toBe('')
+    expect(task.taskKey).toBe('aria2:')
+    expect(task.status).toBe(TASK_STATUS.WAITING)
+  })
+})
+
+describe('adaptGoed2kdTask', () => {
+  it('映射 goed2kd 任务字段与进度', () => {
+    const raw = {
+      hash: VALID_HASH,
+      file_name: 'movie.mkv',
+      file_path: '/downloads/movie.mkv',
+      total_wanted: 1000,
+      total_done: 250,
+      download_rate: 128000,
+      status: 'downloading'
+    }
+    const task = adaptGoed2kdTask(raw)
+
+    expect(task).toMatchObject({
+      engine: 'goed2kd',
+      id: VALID_HASH,
+      gid: VALID_HASH,
+      hash: VALID_HASH,
+      taskKey: `goed2kd:${VALID_HASH}`,
+      status: TASK_STATUS.ACTIVE,
+      name: 'movie.mkv',
+      completedLength: 250,
+      totalLength: 1000,
+      downloadSpeed: 128000,
+      progress: 0.25,
+      dir: '/downloads',
+      bittorrent: null,
+      peers: []
+    })
+    expect(task.files).toEqual([{ path: '/downloads/movie.mkv' }])
+    expect(task.raw).toBe(raw)
+  })
+
+  it('兼容 size 与 state 字段', () => {
+    const task = adaptGoed2kdTask({
+      hash: VALID_HASH,
+      size: 500,
+      state: 'paused'
+    })
+
+    expect(task.totalLength).toBe(500)
+    expect(task.status).toBe(TASK_STATUS.PAUSED)
+    expect(task.name).toBe(VALID_HASH)
+    expect(task.files).toEqual([])
+    expect(task.dir).toBe('')
+  })
+
+  it('非法数值回退为 0', () => {
+    const task = adaptGoed2kdTask({
+      hash: VALID_HASH,
+      total_done: 'bad',
+      download_rate: null
+    })
+
+    expect(task.completedLength).toBe(0)
+    expect(task.downloadSpeed).toBe(0)
+    expect(task.progress).toBe(0)
+  })
+})
+
+describe('adaptTaskForMainFlow', () => {
+  it('按 engine 分发到对应适配器', () => {
+    const aria2 = adaptTaskForMainFlow({ gid: 'g1', status: 'active' })
+    expect(aria2.engine).toBe('aria2')
+
+    const goed2kd = adaptTaskForMainFlow({
+      engine: 'goed2kd',
+      hash: VALID_HASH,
+      status: 'complete'
+    })
+    expect(goed2kd.engine).toBe('goed2kd')
+    expect(goed2kd.status).toBe(TASK_STATUS.COMPLETE)
+  })
+})
+
+describe('getTaskDisplayName', () => {
+  it('BT 任务显示 torrent 名称', () => {
+    const name = getTaskDisplayName({
+      files: [{ path: '/tmp/a.mkv' }],
+      bittorrent: { info: { name: 'Season 1' } }
+    })
+    expect(name).toBe('Season 1')
+  })
+
+  it('goed2kd 任务显示 file_name', () => {
+    const name = getTaskDisplayName({
+      engine: 'goed2kd',
+      file_name: 'demo.mkv',
+      name: VALID_HASH
+    })
+    expect(name).toBe('demo.mkv')
+  })
+
+  it('无 task 时返回默认名称', () => {
+    expect(getTaskDisplayName(null)).toBe('Unknown')
+  })
+})

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -22,6 +22,7 @@ export default defineConfig({
         'src/main/utils/**/*.js',
         'src/main/configs/**/*.js',
         'src/main/core/**/*.js',
+        'src/renderer/store/**/*.js',
         'src/renderer/components/**/*.vue'
       ],
       reporter: ['text', 'lcov']


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

补充第二批单元测试，覆盖双引擎任务适配层与 ED2K 客户端 HTTP 封装。

### 新增测试文件

| 文件 | 覆盖模块 |
|------|---------|
| `tests/renderer/store/taskAdapter.test.js` | `buildTaskKey`、`adaptAria2Task`、`adaptGoed2kdTask`、`adaptTaskForMainFlow`、`getTaskDisplayName` |
| `tests/main/core/Goed2kdClient.test.js` | `getBaseUrl`、`getAuthHeader`、`request` 错误处理及 transfers/searches 全部 API |

### 配置变更

- `vitest.config.js`：将 `src/renderer/store/**/*.js` 纳入覆盖率统计

### 覆盖率变化

- 测试用例：**199 → 223**（全部通过）
- `taskAdapter.js` 行覆盖率：**100%**
- `Goed2kdClient.js` 行覆盖率：**~100%**

### Checklist

* [x] `pnpm run lint` 通过
* [x] `pnpm run test` 全部通过
* [ ] 未改动业务代码，无需手动运行应用

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ba293e0-5537-4e8d-9e69-a2241ea4eed7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ba293e0-5537-4e8d-9e69-a2241ea4eed7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

