### PR TITLE
test(renderer): 补充第三批 Task 相关 Vue 组件单元测试

### DIFF
--- a/tests/helpers/vue-test-helpers.js
+++ b/tests/helpers/vue-test-helpers.js
@@ -85,11 +85,30 @@ const testMessages = {
     'uri-task': '链接任务',
     'torrent-task': '种子任务',
     'thunder-link-tips': '检测到迅雷链接',
-    'show-advanced-options': '高级选项'
+    'show-advanced-options': '高级选项',
+    'get-task-name': '未知任务',
+    'opening-task-message': '正在打开 {taskName}',
+    'file-not-exist': '文件不存在',
+    'delete-task': '删除任务',
+    'select-torrent': '选择种子文件',
+    'task-add': '新建任务',
+    'new-task': '新建任务',
+    'task-all-start': '全部开始',
+    'task-all-stop': '全部暂停',
+    'post-download-action-menu': '下载完成后',
+    'post-download-action-none': '无操作',
+    'post-download-action-shutdown': '关机',
+    'post-download-action-sleep': '睡眠',
+    'post-download-action-quit': '退出应用',
+    'remaining-prefix': '剩余'
   },
   app: {
     cancel: '取消',
-    submit: '提交'
+    submit: '提交',
+    gt1d: '>1天',
+    hour: '时',
+    minute: '分',
+    second: '秒'
   }
 }
 
@@ -140,15 +159,31 @@ export const createTestStore = (overrides = {}) => {
           taskList: [],
           addTaskUrl: '',
           addTaskOptions: {},
+          addTaskTorrents: [],
           ...(overrides.appState || {})
         },
-        actions: appActions
+        actions: {
+          showAddTaskDialog: vi.fn(),
+          addTaskAddTorrents: vi.fn(),
+          ...appActions
+        }
       },
       task: {
         namespaced: true,
+        state: {
+          selectedTaskKeyList: [],
+          currentList: 'all',
+          onCompleteAction: 'none',
+          ...(overrides.taskState || {})
+        },
         actions: {
           addUri: vi.fn(() => Promise.resolve()),
           addTorrent: vi.fn(() => Promise.resolve()),
+          toggleTask: vi.fn(),
+          fetchList: vi.fn(),
+          resumeAllTask: vi.fn(() => Promise.resolve()),
+          pauseAllTask: vi.fn(() => Promise.resolve()),
+          setOnCompleteAction: vi.fn(),
           ...(overrides.taskActions || {})
         }
       }

--- a/tests/renderer/components/Task/BatchDeleteTaskBtn.test.js
+++ b/tests/renderer/components/Task/BatchDeleteTaskBtn.test.js
@@ -1,0 +1,55 @@
+import { shallowMount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  createTestI18n,
+  elementPlusStubs
+} from '../../../helpers/vue-test-helpers.js'
+
+const commandsEmit = vi.hoisted(() => vi.fn())
+
+vi.mock('@/components/CommandManager/instance', () => ({
+  commands: { emit: commandsEmit }
+}))
+
+const { default: BatchDeleteTaskBtn } = await import('@/components/Task/BatchDeleteTaskBtn.vue')
+
+describe('BatchDeleteTaskBtn', () => {
+  beforeEach(() => {
+    commandsEmit.mockClear()
+  })
+
+  it('点击时发出 batch-delete-task 命令', async () => {
+    const wrapper = shallowMount(BatchDeleteTaskBtn, {
+      global: {
+        plugins: [createTestI18n()],
+        stubs: {
+          ...elementPlusStubs,
+          'mo-icon': true
+        }
+      }
+    })
+
+    await wrapper.find('.el-button').trigger('click')
+    expect(commandsEmit).toHaveBeenCalledWith('batch-delete-task', {
+      deleteWithFiles: false
+    })
+  })
+
+  it('Shift+点击时删除本地文件', () => {
+    const wrapper = shallowMount(BatchDeleteTaskBtn, {
+      global: {
+        plugins: [createTestI18n()],
+        stubs: {
+          ...elementPlusStubs,
+          'mo-icon': true
+        }
+      }
+    })
+
+    wrapper.vm.onBatchDeleteClick({ shiftKey: true })
+    expect(commandsEmit).toHaveBeenCalledWith('batch-delete-task', {
+      deleteWithFiles: true
+    })
+  })
+})

--- a/tests/renderer/components/Task/SelectTorrent.test.js
+++ b/tests/renderer/components/Task/SelectTorrent.test.js
@@ -1,0 +1,102 @@
+import { shallowMount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  EMPTY_STRING,
+  NONE_SELECTED_FILES
+} from '@shared/constants'
+import {
+  createTestI18n,
+  createTestStore,
+  elementPlusStubs
+} from '../../../helpers/vue-test-helpers.js'
+
+vi.mock('@/components/TaskDetail/TaskFiles', () => ({
+  default: {
+    name: 'mo-task-files',
+    template: '<div class="task-files-stub" />',
+    methods: {
+      toggleAllSelection: vi.fn(),
+      clearSelection: vi.fn()
+    }
+  }
+}))
+
+const { default: SelectTorrent } = await import('@/components/Task/SelectTorrent.vue')
+
+describe('SelectTorrent', () => {
+  const mountSelectTorrent = (storeOverrides = {}) => {
+    const store = createTestStore(storeOverrides)
+    return {
+      store,
+      wrapper: shallowMount(SelectTorrent, {
+        global: {
+          plugins: [store, createTestI18n()],
+          stubs: {
+            ...elementPlusStubs,
+            'mo-task-files': true,
+            'mo-icon': true,
+            'el-upload': { template: '<div class="el-upload"><slot /></div>' },
+            'el-tooltip': { template: '<div><slot /></div>' }
+          }
+        }
+      })
+    }
+  }
+
+  it('无种子文件时显示上传区域', () => {
+    const { wrapper } = mountSelectTorrent()
+    expect(wrapper.vm.isTorrentsEmpty).toBe(true)
+    expect(wrapper.find('.el-upload').exists()).toBe(true)
+  })
+
+  it('已有种子文件时显示文件列表区域', () => {
+    const { wrapper } = mountSelectTorrent({
+      appState: {
+        addTaskTorrents: [{ name: 'demo.torrent', raw: {} }]
+      }
+    })
+    expect(wrapper.vm.isTorrentsEmpty).toBe(false)
+    expect(wrapper.find('.selective-torrent').exists()).toBe(true)
+  })
+
+  it('选择文件时 dispatch addTaskAddTorrents', () => {
+    const { wrapper, store } = mountSelectTorrent()
+    const dispatchSpy = vi.spyOn(store, 'dispatch')
+    const fileList = [{ name: 'demo.torrent' }]
+
+    wrapper.vm.handleChange({}, fileList)
+    expect(dispatchSpy).toHaveBeenCalledWith('app/addTaskAddTorrents', { fileList })
+  })
+
+  it('删除种子时清空 store 中的 torrent 列表', () => {
+    const { wrapper, store } = mountSelectTorrent({
+      appState: {
+        addTaskTorrents: [{ name: 'demo.torrent', raw: {} }]
+      }
+    })
+    const dispatchSpy = vi.spyOn(store, 'dispatch')
+
+    wrapper.vm.handleTrashClick()
+    expect(dispatchSpy).toHaveBeenCalledWith('app/addTaskAddTorrents', { fileList: [] })
+  })
+
+  it('reset 时发出空 torrent 变更事件', () => {
+    const { wrapper } = mountSelectTorrent()
+    wrapper.vm.name = 'demo.torrent'
+    wrapper.vm.currentTorrent = 'base64-data'
+
+    wrapper.vm.reset()
+    expect(wrapper.vm.name).toBe(EMPTY_STRING)
+    expect(wrapper.vm.currentTorrent).toBe(EMPTY_STRING)
+    expect(wrapper.emitted('torrent-change')).toEqual([[EMPTY_STRING, NONE_SELECTED_FILES]])
+  })
+
+  it('currentTorrent 为空时不向外冒泡 selection-change', () => {
+    const { wrapper } = mountSelectTorrent()
+    wrapper.vm.currentTorrent = EMPTY_STRING
+
+    wrapper.vm.handleSelectionChange('1')
+    expect(wrapper.emitted('torrent-change')).toBeUndefined()
+  })
+})

--- a/tests/renderer/components/Task/TaskActions.test.js
+++ b/tests/renderer/components/Task/TaskActions.test.js
@@ -1,0 +1,73 @@
+import { shallowMount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ADD_TASK_TYPE } from '@shared/constants'
+import {
+  createTestI18n,
+  createTestStore,
+  elementPlusStubs
+} from '../../../helpers/vue-test-helpers.js'
+
+const commandsEmit = vi.hoisted(() => vi.fn())
+
+vi.mock('@/components/CommandManager/instance', () => ({
+  commands: { emit: commandsEmit }
+}))
+
+const { default: TaskActions } = await import('@/components/Task/TaskActions.vue')
+
+describe('TaskActions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    commandsEmit.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const mountTaskActions = () => {
+    const store = createTestStore()
+    return {
+      store,
+      wrapper: shallowMount(TaskActions, {
+        global: {
+          plugins: [store, createTestI18n()],
+          stubs: {
+            ...elementPlusStubs,
+            'mo-icon': true
+          }
+        }
+      })
+    }
+  }
+
+  it('点击新建任务时打开 URI 添加对话框', () => {
+    const { wrapper, store } = mountTaskActions()
+    const dispatchSpy = vi.spyOn(store, 'dispatch')
+
+    wrapper.vm.onAddClick()
+    expect(dispatchSpy).toHaveBeenCalledWith('app/showAddTaskDialog', ADD_TASK_TYPE.URI)
+  })
+
+  it('点击刷新时拉取列表并显示旋转动画', async () => {
+    const { wrapper, store } = mountTaskActions()
+    const dispatchSpy = vi.spyOn(store, 'dispatch')
+
+    wrapper.vm.onRefreshClick()
+    expect(dispatchSpy).toHaveBeenCalledWith('task/fetchList')
+    expect(wrapper.vm.refreshing).toBe(true)
+
+    vi.advanceTimersByTime(500)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.refreshing).toBe(false)
+  })
+
+  it('Shift+批量删除时携带 deleteWithFiles', () => {
+    const { wrapper } = mountTaskActions()
+    wrapper.vm.onBatchDeleteClick({ shiftKey: true })
+    expect(commandsEmit).toHaveBeenCalledWith('batch-delete-task', {
+      deleteWithFiles: true
+    })
+  })
+})

--- a/tests/renderer/components/Task/TaskItem.test.js
+++ b/tests/renderer/components/Task/TaskItem.test.js
@@ -1,0 +1,104 @@
+import { shallowMount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+
+import { TASK_STATUS } from '@shared/constants'
+import {
+  createTestI18n,
+  createTestStore,
+  elementPlusStubs
+} from '../../../helpers/vue-test-helpers.js'
+
+vi.mock('@/utils/native', () => ({
+  openItem: vi.fn(() => Promise.resolve('')),
+  getTaskFullPath: vi.fn(() => '/downloads/demo.zip')
+}))
+
+vi.mock('@/components/Task/TaskItemActions', () => ({
+  default: { name: 'mo-task-item-actions', template: '<div class="task-item-actions-stub" />' }
+}))
+
+const { default: TaskItem } = await import('@/components/Task/TaskItem.vue')
+
+const baseTask = {
+  taskKey: 'aria2:gid-1',
+  gid: 'gid-1',
+  status: TASK_STATUS.ACTIVE,
+  totalLength: 1000,
+  completedLength: 500,
+  downloadSpeed: 1024,
+  uploadSpeed: 0,
+  connections: 8,
+  files: [{ path: '/downloads/demo.zip' }]
+}
+
+describe('TaskItem', () => {
+  const mountTaskItem = (task = baseTask, storeOverrides = {}) => {
+    const store = createTestStore(storeOverrides)
+    const msg = vi.fn()
+    msg.info = vi.fn()
+    msg.error = vi.fn()
+
+    const wrapper = shallowMount(TaskItem, {
+      props: { task },
+      global: {
+        plugins: [store, createTestI18n()],
+        stubs: {
+          ...elementPlusStubs,
+          'mo-task-item-actions': true,
+          'mo-icon': true
+        },
+        mocks: { $msg: msg }
+      }
+    })
+
+    return { wrapper, store, msg }
+  }
+
+  it('展示任务名、连接数与速度', () => {
+    const { wrapper } = mountTaskItem()
+    expect(wrapper.text()).toContain('demo.zip')
+    expect(wrapper.text()).toContain('8')
+    expect(wrapper.text()).toContain('/s')
+  })
+
+  it('按进度设置行内 CSS 变量', () => {
+    const { wrapper } = mountTaskItem()
+    expect(wrapper.attributes('style')).toContain('--task-row-progress: 50%')
+  })
+
+  it('已完成任务进度为 100%', () => {
+    const { wrapper } = mountTaskItem({
+      ...baseTask,
+      status: TASK_STATUS.COMPLETE,
+      completedLength: 1000
+    })
+    expect(wrapper.vm.rowProgressPercent).toBe(100)
+    expect(wrapper.attributes('style')).toContain('--task-row-progress: 100%')
+  })
+
+  it('双击已完成任务时打开文件', async () => {
+    const { wrapper, msg } = mountTaskItem({
+      ...baseTask,
+      status: TASK_STATUS.COMPLETE,
+      completedLength: 1000,
+      bittorrent: { info: { name: 'archive.zip' } },
+      files: [{ path: '/downloads/archive.zip' }]
+    })
+
+    await wrapper.vm.onDbClick()
+    expect(msg.info).toHaveBeenCalled()
+  })
+
+  it('双击等待中任务时切换任务状态', () => {
+    const { wrapper, store } = mountTaskItem({
+      ...baseTask,
+      status: TASK_STATUS.WAITING
+    })
+    const dispatchSpy = vi.spyOn(store, 'dispatch')
+
+    wrapper.vm.onDbClick()
+    expect(dispatchSpy).toHaveBeenCalledWith('task/toggleTask', expect.objectContaining({
+      status: TASK_STATUS.WAITING
+    }))
+  })
+})

--- a/tests/renderer/components/Task/TaskItemActions.test.js
+++ b/tests/renderer/components/Task/TaskItemActions.test.js
@@ -1,0 +1,112 @@
+import { shallowMount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { TASK_STATUS } from '@shared/constants'
+import {
+  createTestI18n,
+  createTestStore,
+  elementPlusStubs
+} from '../../../helpers/vue-test-helpers.js'
+
+const commandsEmit = vi.hoisted(() => vi.fn())
+
+vi.mock('electron-is', () => ({
+  default: {
+    renderer: () => true,
+    mas: () => false
+  }
+}))
+
+vi.mock('@/utils/native', () => ({
+  getTaskFullPath: vi.fn(() => '/downloads/demo.zip')
+}))
+
+vi.mock('@/components/CommandManager/instance', () => ({
+  commands: { emit: commandsEmit }
+}))
+
+const { default: TaskItemActions } = await import('@/components/Task/TaskItemActions.vue')
+
+const baseTask = {
+  taskKey: 'aria2:gid-1',
+  gid: 'gid-1',
+  status: TASK_STATUS.ACTIVE,
+  files: [{ uris: [{ uri: 'https://example.com/file.zip' }] }]
+}
+
+describe('TaskItemActions', () => {
+  beforeEach(() => {
+    commandsEmit.mockClear()
+  })
+
+  const mountActions = (task = baseTask) => {
+    const store = createTestStore()
+    return shallowMount(TaskItemActions, {
+      props: { task, mode: 'LIST' },
+      global: {
+        plugins: [store, createTestI18n()],
+        stubs: {
+          ...elementPlusStubs,
+          'mo-icon': true
+        }
+      }
+    })
+  }
+
+  it('下载中任务显示暂停与删除操作', () => {
+    const wrapper = mountActions()
+    expect(wrapper.vm.taskActions).toEqual(
+      expect.arrayContaining(['PAUSE', 'DELETE', 'FOLDER', 'LINK', 'INFO', 'EDIT_LINK'])
+    )
+  })
+
+  it('已完成任务显示重启与回收站操作', () => {
+    const wrapper = mountActions({
+      ...baseTask,
+      status: TASK_STATUS.COMPLETE
+    })
+    expect(wrapper.vm.taskActions).toEqual(
+      expect.arrayContaining(['RESTART', 'TRASH'])
+    )
+  })
+
+  it('点击暂停时发出 pause-task 命令', () => {
+    const wrapper = mountActions()
+    wrapper.vm.onPauseClick()
+    expect(commandsEmit).toHaveBeenCalledWith('pause-task', expect.objectContaining({
+      task: expect.objectContaining({ gid: 'gid-1' })
+    }))
+  })
+
+  it('Shift+删除时携带 deleteWithFiles', () => {
+    const wrapper = mountActions()
+    wrapper.vm.onDeleteClick({ shiftKey: true })
+    expect(commandsEmit).toHaveBeenCalledWith('delete-task', expect.objectContaining({
+      deleteWithFiles: true
+    }))
+  })
+
+  it('做种任务点击停止时发出 stop-task-seeding', () => {
+    const wrapper = mountActions({
+      ...baseTask,
+      status: TASK_STATUS.ACTIVE,
+      bittorrent: {},
+      seeder: 'true'
+    })
+    wrapper.vm.onStopClick()
+    expect(commandsEmit).toHaveBeenCalledWith('stop-task-seeding', expect.objectContaining({
+      task: expect.objectContaining({ seeder: 'true' })
+    }))
+  })
+
+  it('Alt+重启已完成任务时显示确认对话框', () => {
+    const wrapper = mountActions({
+      ...baseTask,
+      status: TASK_STATUS.COMPLETE
+    })
+    wrapper.vm.onRestartClick({ altKey: true })
+    expect(commandsEmit).toHaveBeenCalledWith('restart-task', expect.objectContaining({
+      showDialog: true
+    }))
+  })
+})

--- a/tests/renderer/components/Task/TaskProgressInfo.test.js
+++ b/tests/renderer/components/Task/TaskProgressInfo.test.js
@@ -1,0 +1,78 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import TaskProgressInfo from '@/components/Task/TaskProgressInfo.vue'
+import { TASK_STATUS } from '@shared/constants'
+import { createTestI18n } from '../../../helpers/vue-test-helpers.js'
+
+describe('TaskProgressInfo', () => {
+  const mountProgressInfo = (task) => {
+    return mount(TaskProgressInfo, {
+      props: { task },
+      global: {
+        plugins: [createTestI18n()],
+        stubs: {
+          'mo-icon': true
+        }
+      }
+    })
+  }
+
+  it('下载中任务显示上下行速度', () => {
+    const wrapper = mountProgressInfo({
+      status: TASK_STATUS.ACTIVE,
+      downloadSpeed: 2048,
+      uploadSpeed: 1024,
+      totalLength: 1000,
+      completedLength: 500,
+      connections: 4,
+      bittorrent: null
+    })
+
+    expect(wrapper.vm.isActive).toBe(true)
+    expect(wrapper.text()).toContain('2.0 KB/s')
+    expect(wrapper.text()).toContain('1.0 KB/s')
+    expect(wrapper.text()).toContain('4')
+  })
+
+  it('非 active 状态不展示速度信息', () => {
+    const wrapper = mountProgressInfo({
+      status: TASK_STATUS.PAUSED,
+      downloadSpeed: 2048,
+      uploadSpeed: 1024,
+      totalLength: 1000,
+      completedLength: 500
+    })
+
+    expect(wrapper.vm.isActive).toBe(false)
+    expect(wrapper.find('.task-speed-info').exists()).toBe(false)
+  })
+
+  it('计算剩余时间', () => {
+    const wrapper = mountProgressInfo({
+      status: TASK_STATUS.ACTIVE,
+      totalLength: 1000,
+      completedLength: 500,
+      downloadSpeed: 100
+    })
+
+    expect(wrapper.vm.remaining).toBe(5)
+    expect(wrapper.text()).toContain('剩余')
+  })
+
+  it('BT 任务显示做种数', () => {
+    const wrapper = mountProgressInfo({
+      status: TASK_STATUS.ACTIVE,
+      downloadSpeed: 100,
+      uploadSpeed: 0,
+      totalLength: 1000,
+      completedLength: 100,
+      connections: 2,
+      numSeeders: 12,
+      bittorrent: {}
+    })
+
+    expect(wrapper.vm.isBT).toBe(true)
+    expect(wrapper.text()).toContain('12')
+  })
+})

--- a/tests/renderer/components/Task/TaskStateAction.test.js
+++ b/tests/renderer/components/Task/TaskStateAction.test.js
@@ -1,0 +1,82 @@
+import { shallowMount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ADD_TASK_TYPE, POST_DOWNLOAD_ACTION } from '@shared/constants'
+import {
+  createTestI18n,
+  createTestStore,
+  elementPlusStubs
+} from '../../../helpers/vue-test-helpers.js'
+
+const { default: TaskStateAction } = await import('@/components/Task/TaskStateAction.vue')
+
+describe('TaskStateAction', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const mountTaskStateAction = (overrides = {}) => {
+    const store = createTestStore(overrides)
+    return {
+      store,
+      wrapper: shallowMount(TaskStateAction, {
+        global: {
+          plugins: [store, createTestI18n()],
+          stubs: {
+            ...elementPlusStubs,
+            'mo-icon': true,
+            'mo-batch-delete-task-btn': true,
+            ArrowDown: true
+          }
+        }
+      })
+    }
+  }
+
+  it('点击新建任务时打开添加对话框', () => {
+    const { wrapper, store } = mountTaskStateAction()
+    const dispatchSpy = vi.spyOn(store, 'dispatch')
+
+    wrapper.vm.onNewTaskClick()
+    expect(dispatchSpy).toHaveBeenCalledWith('app/showAddTaskDialog', ADD_TASK_TYPE.URI)
+  })
+
+  it('设置下载完成后动作为关机', () => {
+    const { wrapper, store } = mountTaskStateAction()
+    const dispatchSpy = vi.spyOn(store, 'dispatch')
+
+    wrapper.vm.onPostDownloadActionCommand(POST_DOWNLOAD_ACTION.SHUTDOWN)
+    expect(dispatchSpy).toHaveBeenCalledWith('task/setOnCompleteAction', POST_DOWNLOAD_ACTION.SHUTDOWN)
+  })
+
+  it('根据 store 显示当前下载完成后动作标签', () => {
+    const { wrapper } = mountTaskStateAction({
+      taskState: { onCompleteAction: POST_DOWNLOAD_ACTION.QUIT }
+    })
+    expect(wrapper.vm.postDownloadActionButtonLabel).toBe('退出应用')
+  })
+
+  it('多选任务时显示批量删除按钮', () => {
+    const { wrapper } = mountTaskStateAction({
+      taskState: {
+        selectedTaskKeyList: ['aria2:a', 'aria2:b'],
+        currentList: 'active'
+      }
+    })
+    expect(wrapper.vm.selectedTaskKeyListCount).toBe(2)
+    expect(wrapper.find('mo-batch-delete-task-btn-stub').exists()).toBe(true)
+  })
+
+  it('刷新时触发 fetchList', () => {
+    const { wrapper, store } = mountTaskStateAction()
+    const dispatchSpy = vi.spyOn(store, 'dispatch')
+
+    wrapper.vm.onRefreshClick()
+    expect(dispatchSpy).toHaveBeenCalledWith('task/fetchList')
+    expect(wrapper.vm.refreshing).toBe(true)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

补充第三批单元测试，覆盖任务列表核心 Vue 组件的渲染与交互逻辑。

### 新增测试文件

| 文件 | 覆盖组件 |
|------|---------|
| `TaskItem.test.js` | 任务名/速度/进度展示、双击打开与切换 |
| `TaskItemActions.test.js` | 按状态渲染操作按钮、命令派发 |
| `TaskProgressInfo.test.js` | 下载速度、剩余时间、BT 做种数 |
| `BatchDeleteTaskBtn.test.js` | 批量删除、Shift 删除本地文件 |
| `TaskActions.test.js` | 新建任务、刷新列表 |
| `TaskStateAction.test.js` | 下载完成后动作、多选批量删除 |
| `SelectTorrent.test.js` | 种子上传/已选切换、清空与事件 |

### 辅助变更

- `tests/helpers/vue-test-helpers.js`：扩展 task/app i18n、task 模块 state/actions

### 覆盖率变化

- 测试用例：**223 → 254**（全部通过）

### Checklist

* [x] `pnpm run lint` 通过
* [x] `pnpm run test` 全部通过
* [ ] 未改动业务代码，无需手动运行应用

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ba293e0-5537-4e8d-9e69-a2241ea4eed7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ba293e0-5537-4e8d-9e69-a2241ea4eed7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

