### PR TITLE
test: 补充第四批 store、aria2、Api 与 CommandManager 单元测试

### DIFF
--- a/tests/renderer/api/Api.test.js
+++ b/tests/renderer/api/Api.test.js
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ipcInvoke = vi.hoisted(() => vi.fn())
+const clientMock = vi.hoisted(() => ({
+  open: vi.fn(() => Promise.resolve()),
+  close: vi.fn(() => Promise.resolve()),
+  call: vi.fn(() => Promise.resolve('ok')),
+  multicall: vi.fn(() => Promise.resolve([]))
+}))
+
+class Aria2Mock {
+  constructor () {
+    Object.assign(this, clientMock)
+  }
+}
+
+vi.mock('electron', () => ({
+  ipcRenderer: { invoke: ipcInvoke }
+}))
+
+vi.mock('electron-is', () => ({
+  default: { renderer: () => true }
+}))
+
+vi.mock('@shared/aria2', () => ({
+  Aria2: Aria2Mock
+}))
+
+const { default: Api } = await import('@/api/Api.js')
+
+describe('Api', () => {
+  let api
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    ipcInvoke.mockResolvedValue({
+      rpcListenPort: 16800,
+      rpcSecret: 'secret',
+      theme: 'light'
+    })
+    api = new Api()
+    await api.init()
+  })
+
+  it('init 后创建 aria2 客户端', () => {
+    expect(api.client).toBeTruthy()
+    expect(api.client.open).toHaveBeenCalled()
+  })
+
+  it('pauseTaskByEngine 按引擎路由', async () => {
+    ipcInvoke.mockResolvedValueOnce({ ok: true })
+    await api.pauseTaskByEngine({ engine: 'goed2kd', id: 'hash1' })
+    expect(ipcInvoke).toHaveBeenCalledWith('goed2kd:pause-download', { hash: 'hash1' })
+
+    await api.pauseTaskByEngine({ engine: 'aria2', gid: 'g1' })
+    expect(clientMock.call).toHaveBeenCalledWith('pause', 'g1')
+  })
+
+  it('savePreference 空配置直接返回 ok', async () => {
+    const result = await api.savePreference({})
+    expect(result).toEqual({ ok: true })
+    expect(ipcInvoke).not.toHaveBeenCalledWith('application:save-preference', expect.anything())
+  })
+
+  it('changeUri 在 method not found 时抛出 CHANGE_URI_NOT_SUPPORTED', async () => {
+    clientMock.call.mockRejectedValueOnce({ code: -32601, message: 'Method not found' })
+    await expect(api.changeUri({ gid: 'g1', fileIndex: 1, addUris: ['https://x.com'] }))
+      .rejects.toMatchObject({ code: 'CHANGE_URI_NOT_SUPPORTED' })
+  })
+
+  it('getGlobalOption 将键名转为 camelCase', async () => {
+    clientMock.call.mockResolvedValueOnce({ 'max-connection-per-server': '16' })
+    const options = await api.getGlobalOption()
+    expect(options).toEqual({ maxConnectionPerServer: '16' })
+  })
+})

--- a/tests/renderer/components/CommandManager/index.test.js
+++ b/tests/renderer/components/CommandManager/index.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import CommandManager from '@/components/CommandManager/index.js'
+
+describe('CommandManager', () => {
+  it('注册并执行命令', () => {
+    const manager = new CommandManager()
+    const handler = vi.fn(() => 'done')
+
+    manager.register('test-cmd', handler)
+    expect(manager.execute('test-cmd', 1, 2)).toBe('done')
+    expect(handler).toHaveBeenCalledWith(1, 2)
+  })
+
+  it('重复注册返回 null', () => {
+    const manager = new CommandManager()
+    manager.register('dup', vi.fn())
+    expect(manager.register('dup', vi.fn())).toBeNull()
+  })
+
+  it('缺少 id 或函数时不注册', () => {
+    const manager = new CommandManager()
+    expect(manager.register('', vi.fn())).toBeNull()
+    expect(manager.register('no-fn')).toBeNull()
+  })
+
+  it('注销后 execute 返回 false', () => {
+    const manager = new CommandManager()
+    manager.register('temp', vi.fn())
+    manager.unregister('temp')
+    expect(manager.execute('temp')).toBe(false)
+  })
+
+  it('注册与注销时发出事件', () => {
+    const manager = new CommandManager()
+    const registered = vi.fn()
+    const unregistered = vi.fn()
+
+    manager.on('commandRegistered', registered)
+    manager.on('commandUnregistered', unregistered)
+    manager.register('evt', vi.fn())
+    manager.unregister('evt')
+
+    expect(registered).toHaveBeenCalledWith('evt')
+    expect(unregistered).toHaveBeenCalledWith('evt')
+  })
+})

--- a/tests/renderer/store/modules/app.test.js
+++ b/tests/renderer/store/modules/app.test.js
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ADD_TASK_TYPE } from '@shared/constants'
+
+vi.mock('@/utils/native', () => ({
+  getSystemTheme: vi.fn(() => 'light')
+}))
+
+const apiMock = vi.hoisted(() => ({
+  getVersion: vi.fn(() => Promise.resolve({ version: '1.0' })),
+  getGlobalOption: vi.fn(() => Promise.resolve({ maxConnections: 16 })),
+  getGlobalStat: vi.fn(() => Promise.resolve({
+    downloadSpeed: '1024',
+    uploadSpeed: '0',
+    numActive: '2',
+    numWaiting: '1',
+    numStopped: '3'
+  })),
+  getGoed2kdStatus: vi.fn(() => Promise.resolve({ healthy: true })),
+  fetchActiveTaskList: vi.fn(() => Promise.resolve([]))
+}))
+
+vi.mock('@/api', () => ({
+  default: apiMock
+}))
+
+const { default: appModule } = await import('@/store/modules/app')
+
+describe('store/modules/app', () => {
+  let state
+
+  beforeEach(() => {
+    state = {
+      ...appModule.state,
+      interval: 1000,
+      addTaskVisible: false,
+      addTaskType: ADD_TASK_TYPE.URI,
+      addTaskUrl: 'old',
+      addTaskTorrents: [{ name: 'a.torrent' }],
+      stat: { downloadSpeed: 0, uploadSpeed: 0, numActive: 0, numWaiting: 0, numStopped: 0 }
+    }
+    vi.clearAllMocks()
+  })
+
+  describe('mutations', () => {
+    it('UPDATE_INTERVAL 限制在最小/最大范围内', () => {
+      appModule.mutations.UPDATE_INTERVAL(state, 100)
+      expect(state.interval).toBe(500)
+      appModule.mutations.UPDATE_INTERVAL(state, 9000)
+      expect(state.interval).toBe(6000)
+    })
+
+    it('UPDATE_ADD_TASK_VISIBLE 与 UPDATE_ADD_TASK_TYPE', () => {
+      appModule.mutations.UPDATE_ADD_TASK_VISIBLE(state, true)
+      appModule.mutations.UPDATE_ADD_TASK_TYPE(state, ADD_TASK_TYPE.TORRENT)
+      expect(state.addTaskVisible).toBe(true)
+      expect(state.addTaskType).toBe(ADD_TASK_TYPE.TORRENT)
+    })
+  })
+
+  describe('actions', () => {
+    it('showAddTaskDialog 设置类型并显示', () => {
+      const commit = vi.fn()
+      appModule.actions.showAddTaskDialog({ commit }, ADD_TASK_TYPE.TORRENT)
+      expect(commit).toHaveBeenCalledWith('UPDATE_ADD_TASK_TYPE', ADD_TASK_TYPE.TORRENT)
+      expect(commit).toHaveBeenCalledWith('UPDATE_ADD_TASK_VISIBLE', true)
+    })
+
+    it('hideAddTaskDialog 重置添加任务状态', () => {
+      const commit = vi.fn()
+      appModule.actions.hideAddTaskDialog({ commit })
+      expect(commit).toHaveBeenCalledWith('UPDATE_ADD_TASK_VISIBLE', false)
+      expect(commit).toHaveBeenCalledWith('UPDATE_ADD_TASK_URL', '')
+      expect(commit).toHaveBeenCalledWith('UPDATE_ADD_TASK_TORRENTS', [])
+    })
+
+    it('fetchGlobalStat 有活动任务时缩短轮询间隔', async () => {
+      const commit = vi.fn()
+      const dispatch = vi.fn()
+      await appModule.actions.fetchGlobalStat({ commit, dispatch })
+      expect(commit).toHaveBeenCalledWith('UPDATE_GLOBAL_STAT', expect.objectContaining({
+        numActive: 2,
+        downloadSpeed: 1024
+      }))
+      expect(dispatch).toHaveBeenCalledWith('updateInterval', 800)
+    })
+
+    it('fetchEngineInfo 成功时更新引擎信息', async () => {
+      const commit = vi.fn()
+      await appModule.actions.fetchEngineInfo({ commit })
+      expect(commit).toHaveBeenCalledWith('UPDATE_ENGINE_INFO', { version: '1.0' })
+    })
+  })
+})

--- a/tests/renderer/store/modules/preference.test.js
+++ b/tests/renderer/store/modules/preference.test.js
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { APP_THEME } from '@shared/constants'
+
+const apiMock = vi.hoisted(() => ({
+  savePreference: vi.fn(() => Promise.resolve({ ok: true })),
+  fetchPreference: vi.fn(() => Promise.resolve({ theme: APP_THEME.DARK }))
+}))
+
+vi.mock('@/api', () => ({
+  default: apiMock
+}))
+
+vi.mock('@shared/utils/tracker', () => ({
+  fetchBtTrackerFromSource: vi.fn(() => Promise.resolve(['udp://tracker.example.com']))
+}))
+
+const { default: preferenceModule } = await import('@/store/modules/preference')
+
+describe('store/modules/preference', () => {
+  let state
+
+  beforeEach(() => {
+    state = {
+      engineMode: 'MAX',
+      config: {
+        theme: APP_THEME.LIGHT,
+        locale: 'zh-CN',
+        historyDirectories: ['/downloads'],
+        favoriteDirectories: [],
+        proxy: { enable: false }
+      }
+    }
+    vi.clearAllMocks()
+  })
+
+  describe('getters', () => {
+    it('返回主题、语言与文字方向', () => {
+      expect(preferenceModule.getters.theme(state)).toBe(APP_THEME.LIGHT)
+      expect(preferenceModule.getters.locale(state)).toBe('zh-CN')
+      expect(preferenceModule.getters.direction(state)).toBe('ltr')
+    })
+  })
+
+  describe('actions', () => {
+    it('updatePreference 合并配置', () => {
+      const commit = vi.fn()
+      preferenceModule.actions.updatePreference({ commit }, { theme: APP_THEME.DARK })
+      expect(commit).toHaveBeenCalledWith('UPDATE_PREFERENCE_DATA', { theme: APP_THEME.DARK })
+    })
+
+    it('save 空配置时直接 resolve', async () => {
+      const dispatch = vi.fn()
+      await preferenceModule.actions.save({ dispatch }, {})
+      expect(apiMock.savePreference).not.toHaveBeenCalled()
+      expect(dispatch).toHaveBeenCalledWith('task/saveSession', null, { root: true })
+    })
+
+    it('recordHistoryDirectory 跳过已存在目录', () => {
+      const dispatch = vi.fn()
+      preferenceModule.actions.recordHistoryDirectory(
+        { state, dispatch },
+        '/downloads'
+      )
+      expect(dispatch).not.toHaveBeenCalled()
+    })
+
+    it('addHistoryDirectory 追加并保存', () => {
+      const dispatch = vi.fn()
+      preferenceModule.actions.addHistoryDirectory(
+        { state, dispatch },
+        '/new/path'
+      )
+      expect(dispatch).toHaveBeenCalledWith('save', {
+        historyDirectories: ['/downloads', '/new/path']
+      })
+    })
+
+    it('fetchBtTracker 调用 tracker 工具', async () => {
+      const { fetchBtTrackerFromSource } = await import('@shared/utils/tracker')
+      const rows = await preferenceModule.actions.fetchBtTracker(null, ['https://source'])
+      expect(fetchBtTrackerFromSource).toHaveBeenCalledWith(
+        ['https://source'],
+        { enable: false }
+      )
+      expect(rows).toEqual(['udp://tracker.example.com'])
+    })
+  })
+})

--- a/tests/renderer/store/modules/task.test.js
+++ b/tests/renderer/store/modules/task.test.js
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { POST_DOWNLOAD_ACTION, TASK_STATUS } from '@shared/constants'
+
+const ipcSend = vi.hoisted(() => vi.fn())
+const apiMock = vi.hoisted(() => ({
+  pauseTaskByEngine: vi.fn(() => Promise.resolve()),
+  resumeTaskByEngine: vi.fn(() => Promise.resolve()),
+  batchResumeTask: vi.fn(() => Promise.resolve()),
+  batchPauseTask: vi.fn(() => Promise.resolve()),
+  fetchTaskList: vi.fn(() => Promise.resolve([])),
+  getGoed2kdStatus: vi.fn(() => Promise.resolve({ healthy: false }))
+}))
+
+vi.mock('electron', () => ({
+  ipcRenderer: {
+    send: ipcSend,
+    invoke: vi.fn()
+  }
+}))
+
+vi.mock('@/api', () => ({
+  default: apiMock
+}))
+
+const { default: taskModule } = await import('@/store/modules/task')
+
+const baseTask = {
+  taskKey: 'goed2kd:hash1',
+  engine: 'goed2kd',
+  gid: 'hash1',
+  status: TASK_STATUS.ACTIVE
+}
+
+describe('store/modules/task', () => {
+  let state
+
+  beforeEach(() => {
+    state = {
+      ...taskModule.state,
+      taskList: [
+        { taskKey: 'aria2:g1', gid: 'g1' },
+        { taskKey: 'aria2:g2', gid: 'g2' }
+      ],
+      selectedTaskKeyList: ['aria2:g1'],
+      taskStatusSnapshot: {}
+    }
+    vi.clearAllMocks()
+  })
+
+  describe('actions', () => {
+    it('setOnCompleteAction 写入状态', () => {
+      const commit = vi.fn()
+      taskModule.actions.setOnCompleteAction(
+        { commit },
+        POST_DOWNLOAD_ACTION.SHUTDOWN
+      )
+      expect(commit).toHaveBeenCalledWith('SET_ON_COMPLETE_ACTION', POST_DOWNLOAD_ACTION.SHUTDOWN)
+    })
+
+    it('selectTasks 与 selectAllTask 更新选中列表', () => {
+      const commit = vi.fn()
+      taskModule.actions.selectTasks({ commit }, ['aria2:g2'])
+      expect(commit).toHaveBeenCalledWith('UPDATE_SELECTED_TASK_KEY_LIST', ['aria2:g2'])
+
+      taskModule.actions.selectAllTask({ commit, state })
+      expect(commit).toHaveBeenCalledWith('UPDATE_SELECTED_TASK_KEY_LIST', ['aria2:g1', 'aria2:g2'])
+    })
+
+    it('toggleTask 对 active 任务调用 pauseTask', () => {
+      const dispatch = vi.fn()
+      const task = { status: TASK_STATUS.ACTIVE, gid: 'g1' }
+      taskModule.actions.toggleTask({ dispatch }, task)
+      expect(dispatch).toHaveBeenCalledWith('pauseTask', task)
+    })
+
+    it('toggleTask 对 paused 任务调用 resumeTask', () => {
+      const dispatch = vi.fn()
+      const task = { status: TASK_STATUS.PAUSED, gid: 'g1' }
+      taskModule.actions.toggleTask({ dispatch }, task)
+      expect(dispatch).toHaveBeenCalledWith('resumeTask', task)
+    })
+
+    it('detectGoed2kdCompletedTasks 检测新完成任务', () => {
+      const commit = vi.fn()
+      const dispatch = vi.fn()
+      const completedTask = {
+        ...baseTask,
+        status: TASK_STATUS.COMPLETE
+      }
+
+      state.taskStatusSnapshot = { 'goed2kd:hash1': TASK_STATUS.ACTIVE }
+      taskModule.actions.detectGoed2kdCompletedTasks(
+        { state, commit, dispatch },
+        [completedTask]
+      )
+
+      expect(dispatch).toHaveBeenCalledWith('emitDownloadCompleteEvent', {
+        task: completedTask,
+        isBT: false
+      })
+      expect(commit).toHaveBeenCalledWith(
+        'UPDATE_TASK_STATUS_SNAPSHOT',
+        expect.objectContaining({ 'goed2kd:hash1': TASK_STATUS.COMPLETE })
+      )
+    })
+
+    it('cancelPostDownloadConfirm 重置确认状态与动作', () => {
+      const commit = vi.fn()
+      taskModule.actions.cancelPostDownloadConfirm({ commit })
+      expect(commit).toHaveBeenCalledWith('SET_POST_DOWNLOAD_AWAITING_CONFIRM', false)
+      expect(commit).toHaveBeenCalledWith('SET_ON_COMPLETE_ACTION', POST_DOWNLOAD_ACTION.NONE)
+    })
+
+    it('batchResumeSelectedTasks 仅处理 aria2 任务', async () => {
+      state.selectedTaskKeyList = ['aria2:g1', 'goed2kd:hash1']
+      await taskModule.actions.batchResumeSelectedTasks({ state })
+      expect(apiMock.batchResumeTask).toHaveBeenCalledWith({ gids: ['g1'] })
+    })
+
+    it('hideTaskDetail 关闭详情面板', () => {
+      const commit = vi.fn()
+      taskModule.actions.hideTaskDetail({ commit })
+      expect(commit).toHaveBeenCalledWith('CHANGE_TASK_DETAIL_VISIBLE', false)
+    })
+
+    it('emitDownloadCompleteEvent 发送 IPC 事件', () => {
+      const task = {
+        gid: 'g1',
+        files: [{ path: '/downloads/a.zip' }]
+      }
+      taskModule.actions.emitDownloadCompleteEvent({}, { task, isBT: true })
+      expect(ipcSend).toHaveBeenCalledWith(
+        'event',
+        'task-download-complete',
+        task,
+        expect.any(String),
+        true
+      )
+    })
+  })
+})

--- a/tests/shared/aria2/lib/Aria2.test.js
+++ b/tests/shared/aria2/lib/Aria2.test.js
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('Aria2', () => {
+  let fetchMock
+  let Aria2
+
+  beforeEach(async () => {
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn()
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    vi.resetModules()
+    const mod = await import('@shared/aria2/lib/Aria2.js')
+    Aria2 = mod.Aria2
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.resetModules()
+  })
+
+  it('prefix 为 aria2 方法补全前缀', () => {
+    const client = new Aria2()
+    expect(client.prefix('getVersion')).toBe('aria2.getVersion')
+    expect(client.prefix('aria2.tellActive')).toBe('aria2.tellActive')
+    expect(client.prefix('system.listMethods')).toBe('system.listMethods')
+  })
+
+  it('unprefix 去掉 aria2 前缀', () => {
+    const client = new Aria2()
+    expect(client.unprefix('aria2.getVersion')).toBe('getVersion')
+    expect(client.unprefix('system.listMethods')).toBe('system.listMethods')
+  })
+
+  it('addSecret 注入 token 参数', () => {
+    const client = new Aria2({ secret: 'abc' })
+    expect(client.addSecret(['arg1'])).toEqual(['token:abc', 'arg1'])
+    expect(client.addSecret()).toEqual(['token:abc'])
+  })
+
+  it('call 自动补全 method 前缀并附加 secret', async () => {
+    const client = new Aria2({ host: '127.0.0.1', port: 16800, secret: 'secret' })
+    client._send = vi.fn().mockResolvedValue(undefined)
+
+    const resultPromise = client.call('getVersion')
+    await Promise.resolve()
+    const id = Number(Object.keys(client.deferreds)[0])
+    client._onresponse({ id, result: 'ok' })
+
+    await expect(resultPromise).resolves.toBe('ok')
+    expect(client._send).toHaveBeenCalledWith(expect.objectContaining({
+      method: 'aria2.getVersion',
+      params: ['token:secret']
+    }))
+  })
+})

--- a/tests/shared/aria2/lib/Deferred.test.js
+++ b/tests/shared/aria2/lib/Deferred.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import Deferred from '@shared/aria2/lib/Deferred'
+
+describe('Deferred', () => {
+  it('resolve 时 promise 完成', async () => {
+    const deferred = new Deferred()
+    deferred.resolve('ok')
+    await expect(deferred.promise).resolves.toBe('ok')
+  })
+
+  it('reject 时 promise 拒绝', async () => {
+    const deferred = new Deferred()
+    const err = new Error('fail')
+    deferred.reject(err)
+    await expect(deferred.promise).rejects.toBe(err)
+  })
+})

--- a/tests/shared/aria2/lib/JSONRPCClient.test.js
+++ b/tests/shared/aria2/lib/JSONRPCClient.test.js
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('JSONRPCClient', () => {
+  let fetchMock
+  let JSONRPCClient
+
+  beforeEach(async () => {
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn()
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    vi.resetModules()
+    const mod = await import('@shared/aria2/lib/JSONRPCClient.js')
+    JSONRPCClient = mod.JSONRPCClient
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.resetModules()
+  })
+
+  it('url 拼接 http/ws 地址', () => {
+    const client = new JSONRPCClient({ host: '127.0.0.1', port: 16800 })
+    expect(client.url('http')).toBe('http://127.0.0.1:16800/jsonrpc')
+    expect(client.url('ws')).toBe('ws://127.0.0.1:16800/jsonrpc')
+  })
+
+  it('_buildMessage 非字符串 method 时抛出 TypeError', () => {
+    const client = new JSONRPCClient()
+    expect(() => client._buildMessage(123)).toThrow(TypeError)
+  })
+
+  it('call 创建 deferred 并在收到响应后 resolve', async () => {
+    const client = new JSONRPCClient({ host: '127.0.0.1', port: 16800 })
+    client._send = vi.fn().mockResolvedValue(undefined)
+
+    const resultPromise = client.call('getVersion')
+    await Promise.resolve()
+    const id = Number(Object.keys(client.deferreds)[0])
+    client._onresponse({ id, result: '1.36.0' })
+
+    await expect(resultPromise).resolves.toBe('1.36.0')
+  })
+
+  it('_onmessage 处理 RPC 错误响应', async () => {
+    const client = new JSONRPCClient()
+    const deferred = { reject: vi.fn(), resolve: vi.fn() }
+    client.deferreds[1] = deferred
+
+    client._onmessage({ id: 1, error: { code: -32601, message: 'not found' } })
+    expect(deferred.reject).toHaveBeenCalledWith(expect.objectContaining({
+      code: -32601,
+      message: 'not found'
+    }))
+    expect(client.deferreds[1]).toBeUndefined()
+  })
+
+  it('_onmessage 处理通知事件', () => {
+    const client = new JSONRPCClient()
+    const handler = vi.fn()
+    client.on('onDownloadComplete', handler)
+
+    client._onmessage({ method: 'onDownloadComplete', params: ['gid'] })
+    expect(handler).toHaveBeenCalledWith(['gid'])
+  })
+})

--- a/tests/shared/aria2/lib/JSONRPCError.test.js
+++ b/tests/shared/aria2/lib/JSONRPCError.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { JSONRPCError } from '@shared/aria2/lib/JSONRPCError'
+
+describe('JSONRPCError', () => {
+  it('保留 code、message 与 data', () => {
+    const err = new JSONRPCError({
+      message: 'method not found',
+      code: -32601,
+      data: { method: 'aria2.foo' }
+    })
+
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe('JSONRPCError')
+    expect(err.message).toBe('method not found')
+    expect(err.code).toBe(-32601)
+    expect(err.data).toEqual({ method: 'aria2.foo' })
+  })
+
+  it('无 data 时不设置 data 字段', () => {
+    const err = new JSONRPCError({ message: 'error', code: 1 })
+    expect(err.data).toBeUndefined()
+  })
+})

--- a/tests/shared/aria2/lib/promiseEvent.test.js
+++ b/tests/shared/aria2/lib/promiseEvent.test.js
@@ -1,0 +1,21 @@
+import { EventEmitter } from 'node:events'
+import { describe, expect, it } from 'vitest'
+
+import promiseEvent from '@shared/aria2/lib/promiseEvent'
+
+describe('promiseEvent', () => {
+  it('在目标事件触发时 resolve', async () => {
+    const emitter = new EventEmitter()
+    const pending = promiseEvent(emitter, 'open')
+    emitter.emit('open', { ready: true })
+    await expect(pending).resolves.toEqual({ ready: true })
+  })
+
+  it('在 error 事件时 reject', async () => {
+    const emitter = new EventEmitter()
+    const pending = promiseEvent(emitter, 'open')
+    const err = new Error('socket error')
+    emitter.emit('error', err)
+    await expect(pending).rejects.toBe(err)
+  })
+})

--- a/tests/shared/locales/LocaleManager.test.js
+++ b/tests/shared/locales/LocaleManager.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import LocaleManager from '@shared/locales/LocaleManager'
+
+describe('LocaleManager', () => {
+  it('初始化 i18next 并切换语言', async () => {
+    const manager = new LocaleManager({
+      resources: {
+        'en-US': { translation: { hello: 'Hello' } },
+        'zh-CN': { translation: { hello: '你好' } }
+      }
+    })
+
+    await manager.changeLanguage('zh-CN')
+    expect(manager.getI18n().language).toBe('zh-CN')
+    expect(manager.getI18n().t('hello')).toBe('你好')
+  })
+
+  it('changeLanguageByLocale 通过 locale 映射语言', async () => {
+    const manager = new LocaleManager({
+      resources: {
+        'en-US': { translation: { app: 'App' } },
+        'zh-CN': { translation: { app: '应用' } }
+      }
+    })
+
+    await manager.changeLanguageByLocale('zh-CN')
+    expect(manager.getI18n().t('app')).toBe('应用')
+  })
+})

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -19,11 +19,15 @@ export default defineConfig({
       provider: 'v8',
       include: [
         'src/shared/utils/**/*.js',
+        'src/shared/aria2/lib/**/*.js',
+        'src/shared/locales/**/*.js',
         'src/main/utils/**/*.js',
         'src/main/configs/**/*.js',
         'src/main/core/**/*.js',
         'src/renderer/store/**/*.js',
-        'src/renderer/components/**/*.vue'
+        'src/renderer/api/**/*.js',
+        'src/renderer/components/**/*.vue',
+        'src/renderer/components/CommandManager/**/*.js'
       ],
       reporter: ['text', 'lcov']
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

补充第四批单元测试，覆盖 Vuex store 模块、aria2 RPC 客户端、Api 封装与 CommandManager。

### 新增测试文件

| 区域 | 文件 |
|------|------|
| aria2 客户端 | `Deferred`、`promiseEvent`、`JSONRPCError`、`JSONRPCClient`、`Aria2` |
| 国际化 | `LocaleManager` |
| Vuex store | `app`、`preference`、`task` 模块 |
| API 层 | `Api.js`（引擎路由、配置保存、changeUri 降级） |
| 命令系统 | `CommandManager` |

### 配置变更

`vitest.config.js` 扩展覆盖率统计至：
- `src/shared/aria2/lib/**/*.js`
- `src/shared/locales/**/*.js`
- `src/renderer/api/**/*.js`
- `src/renderer/components/CommandManager/**/*.js`

### 覆盖率变化

- 测试用例：**254 → 302**（全部通过）

### Checklist

* [x] `pnpm run lint` 通过
* [x] `pnpm run test` 全部通过
* [ ] 未改动业务代码

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ba293e0-5537-4e8d-9e69-a2241ea4eed7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ba293e0-5537-4e8d-9e69-a2241ea4eed7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

