### PR TITLE
test(main): 补充第五批主进程核心模块单元测试

### DIFF
--- a/tests/helpers/electron-log-mock.js
+++ b/tests/helpers/electron-log-mock.js
@@ -1,0 +1,16 @@
+import { vi } from 'vitest'
+
+export const createElectronLogMock = () => ({
+  default: {
+    transports: {
+      file: {
+        level: 'info',
+        getFile: () => ({ path: '/mock/logs/imfile.log' })
+      }
+    },
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    log: vi.fn()
+  }
+})

--- a/tests/main/core/AutoLaunchManager.test.js
+++ b/tests/main/core/AutoLaunchManager.test.js
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { LOGIN_SETTING_OPTIONS } from '@shared/constants'
+import { createElectronMock } from '../../helpers/electron-mock.js'
+
+const getLoginItemSettings = vi.hoisted(() => vi.fn(() => ({ openAtLogin: false })))
+const setLoginItemSettings = vi.hoisted(() => vi.fn())
+
+vi.mock('electron', () => ({
+  ...createElectronMock(),
+  app: {
+    ...createElectronMock().app,
+    getLoginItemSettings,
+    setLoginItemSettings
+  }
+}))
+
+const { default: AutoLaunchManager } = await import('../../../src/main/core/AutoLaunchManager.js')
+
+describe('AutoLaunchManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getLoginItemSettings.mockReturnValue({ openAtLogin: false })
+  })
+
+  it('enable 设置开机启动', async () => {
+    const manager = new AutoLaunchManager()
+    await manager.enable()
+    expect(setLoginItemSettings).toHaveBeenCalledWith({
+      ...LOGIN_SETTING_OPTIONS,
+      openAtLogin: true
+    })
+  })
+
+  it('enable 在已启用时仍 resolve', async () => {
+    getLoginItemSettings.mockReturnValue({ openAtLogin: true })
+    const manager = new AutoLaunchManager()
+    await expect(manager.enable()).resolves.toBeUndefined()
+  })
+
+  it('disable 关闭开机启动', async () => {
+    const manager = new AutoLaunchManager()
+    await manager.disable()
+    expect(setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: false })
+  })
+
+  it('isEnabled 返回当前状态', async () => {
+    getLoginItemSettings.mockReturnValue({ openAtLogin: true })
+    const manager = new AutoLaunchManager()
+    await expect(manager.isEnabled()).resolves.toBe(true)
+  })
+})

--- a/tests/main/core/Context.test.js
+++ b/tests/main/core/Context.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createElectronIsMock } from '../../helpers/electron-mock.js'
+import { createElectronLogMock } from '../../helpers/electron-log-mock.js'
+
+vi.mock('electron-is', () => createElectronIsMock())
+vi.mock('electron-log', () => createElectronLogMock())
+
+vi.mock('../../../src/main/utils', () => ({
+  getEnginePath: vi.fn(() => '/mock/engine'),
+  getAria2ConfPath: vi.fn(() => '/mock/aria2.conf'),
+  getEngineBinPathByBackend: vi.fn(() => '/mock/aria2c'),
+  getSessionPath: vi.fn(() => '/mock/session'),
+  getGoAria2SessionJsonPath: vi.fn(() => '/mock/session.json'),
+  inferDownloadEngineBackendFromUserStore: vi.fn(() => 'go-aria2')
+}))
+
+const { default: Context } = await import('../../../src/main/core/Context.js')
+
+describe('Context', () => {
+  it('init 后包含平台与引擎路径信息', () => {
+    const configManager = {}
+    const ctx = new Context(configManager)
+    const all = ctx.get()
+
+    expect(all.platform).toBe(process.platform)
+    expect(all.arch).toBe(process.arch)
+    expect(all['engine-bin-path']).toBe('/mock/aria2c')
+    expect(all['log-path']).toBe('/mock/logs/imfile.log')
+  })
+
+  it('get/set 读写单个键', () => {
+    const ctx = new Context({})
+    ctx.set('custom-key', 'value')
+    expect(ctx.get('custom-key')).toBe('value')
+  })
+})

--- a/tests/main/core/EnergyManager.test.js
+++ b/tests/main/core/EnergyManager.test.js
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createElectronMock, createElectronIsMock } from '../../helpers/electron-mock.js'
+import { createElectronLogMock } from '../../helpers/electron-log-mock.js'
+
+const powerSaveBlocker = vi.hoisted(() => ({
+  start: vi.fn(() => 42),
+  stop: vi.fn(),
+  isStarted: vi.fn(() => true)
+}))
+
+vi.mock('electron', () => ({
+  ...createElectronMock(),
+  powerSaveBlocker
+}))
+
+vi.mock('electron-is', () => createElectronIsMock())
+vi.mock('electron-log', () => createElectronLogMock())
+
+const { default: EnergyManager } = await import('../../../src/main/core/EnergyManager.js')
+
+describe('EnergyManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    powerSaveBlocker.isStarted.mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    const manager = new EnergyManager()
+    manager.stopPowerSaveBlocker()
+  })
+
+  it('startPowerSaveBlocker 启动节能阻止', () => {
+    const manager = new EnergyManager()
+    manager.startPowerSaveBlocker()
+    expect(powerSaveBlocker.start).toHaveBeenCalledWith('prevent-app-suspension')
+  })
+
+  it('已启动时不重复 start', () => {
+    powerSaveBlocker.isStarted.mockReturnValue(false)
+    const manager = new EnergyManager()
+    manager.startPowerSaveBlocker()
+    powerSaveBlocker.isStarted.mockImplementation((id) => id === 42)
+    manager.startPowerSaveBlocker()
+    expect(powerSaveBlocker.start).toHaveBeenCalledTimes(1)
+  })
+
+  it('stopPowerSaveBlocker 停止节能阻止', () => {
+    powerSaveBlocker.isStarted.mockReturnValue(true)
+    const manager = new EnergyManager()
+    manager.startPowerSaveBlocker()
+    manager.stopPowerSaveBlocker()
+    expect(powerSaveBlocker.stop).toHaveBeenCalledWith(42)
+  })
+})

--- a/tests/main/core/Engine.test.js
+++ b/tests/main/core/Engine.test.js
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createElectronIsMock } from '../../helpers/electron-mock.js'
+import { createElectronLogMock } from '../../helpers/electron-log-mock.js'
+
+const existsSync = vi.hoisted(() => vi.fn())
+const statSync = vi.hoisted(() => vi.fn())
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    existsSync,
+    statSync
+  }
+})
+
+vi.mock('electron-is', () => createElectronIsMock())
+vi.mock('electron-log', () => createElectronLogMock())
+
+vi.mock('../../../src/main/ui/Locale', () => ({
+  getI18n: () => ({ t: (key) => key })
+}))
+
+vi.mock('../../../src/main/utils/index', () => ({
+  ENGINE_BACKEND: { ARIA2: 'aria2', GO_ARIA2: 'go-aria2' },
+  getEnginePidPath: vi.fn(() => '/tmp/engine.pid'),
+  getEngineBinPathByBackend: vi.fn(() => '/tmp/aria2c'),
+  getAria2ConfPath: vi.fn(() => '/tmp/aria2.conf'),
+  getSessionPath: vi.fn(() => '/tmp/session.txt'),
+  getUserDownloadsPath: vi.fn(() => '/downloads'),
+  getGoAria2DataDir: vi.fn(() => '/tmp/go-aria2'),
+  getGoAria2SessionJsonPath: vi.fn(() => '/tmp/session.json'),
+  getGoAria2MigrationConfPath: vi.fn(() => '/tmp/migrate.conf'),
+  isGoAria2EngineBin: vi.fn(() => false),
+  transformConfig: vi.fn((cfg) => cfg)
+}))
+
+const { default: Engine } = await import('../../../src/main/core/Engine.js')
+
+describe('Engine', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('shouldRunMigrateFromAria2', () => {
+    it('无 legacy session 时返回 false', () => {
+      existsSync.mockReturnValue(false)
+      expect(Engine.shouldRunMigrateFromAria2()).toBe(false)
+    })
+
+    it('legacy session 非空且 go session 不存在时返回 true', () => {
+      existsSync.mockImplementation((p) => p === '/tmp/session.txt')
+      statSync.mockReturnValue({ size: 128 })
+      expect(Engine.shouldRunMigrateFromAria2()).toBe(true)
+    })
+
+    it('legacy session 为空时返回 false', () => {
+      existsSync.mockImplementation((p) => p === '/tmp/session.txt')
+      statSync.mockReturnValue({ size: 0 })
+      expect(Engine.shouldRunMigrateFromAria2()).toBe(false)
+    })
+
+    it('go session 已存在且非空时返回 false', () => {
+      existsSync.mockReturnValue(true)
+      statSync.mockImplementation((p) => ({
+        size: p === '/tmp/session.json' ? 64 : 128
+      }))
+      expect(Engine.shouldRunMigrateFromAria2()).toBe(false)
+    })
+  })
+
+  describe('isRunning', () => {
+    it('当前进程 pid 应视为运行中', () => {
+      const engine = new Engine({ systemConfig: {}, userConfig: {} })
+      expect(engine.isRunning(process.pid)).toBe(true)
+    })
+  })
+})

--- a/tests/main/core/EngineClient.test.js
+++ b/tests/main/core/EngineClient.test.js
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createElectronLogMock } from '../../helpers/electron-log-mock.js'
+
+const aria2Call = vi.hoisted(() => vi.fn(() => Promise.resolve('ok')))
+
+class Aria2Mock {
+  constructor (options) {
+    this.options = options
+    this.call = aria2Call
+  }
+}
+
+vi.mock('@shared/aria2', () => ({
+  Aria2: Aria2Mock
+}))
+
+vi.mock('electron-log', () => createElectronLogMock())
+
+const { default: EngineClient } = await import('../../../src/main/core/EngineClient.js')
+
+describe('EngineClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('connect 时使用传入的 RPC 配置', () => {
+    const client = new EngineClient({ host: '10.0.0.1', port: 16801, secret: 'abc' })
+    expect(client.client).toBeTruthy()
+    expect(client.client.options).toMatchObject({
+      host: '10.0.0.1',
+      port: 16801,
+      secret: 'abc'
+    })
+  })
+
+  it('call 委托给 aria2 客户端', async () => {
+    const client = new EngineClient()
+    await client.call('getVersion')
+    expect(aria2Call).toHaveBeenCalledWith('getVersion')
+  })
+
+  it('call 失败时记录警告并返回 undefined', async () => {
+    aria2Call.mockRejectedValueOnce(new Error('rpc down'))
+    const client = new EngineClient()
+    await expect(client.call('getVersion')).resolves.toBeUndefined()
+  })
+
+  it('shutdown 调用 shutdown 并传入 secret', async () => {
+    const client = new EngineClient({ secret: 'token' })
+    await client.shutdown()
+    expect(aria2Call).toHaveBeenCalledWith('shutdown', 'token')
+  })
+
+  it('force shutdown 使用 forceShutdown 方法', async () => {
+    const client = new EngineClient({ secret: 'token' })
+    await client.shutdown({ force: true })
+    expect(aria2Call).toHaveBeenCalledWith('forceShutdown', 'token')
+  })
+})

--- a/tests/main/core/Goed2kdEngine.test.js
+++ b/tests/main/core/Goed2kdEngine.test.js
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  GOED2KD_DEFAULT_LISTEN_TCP_PORT,
+  GOED2KD_DEFAULT_LISTEN_UDP_PORT
+} from '@shared/constants'
+import { createElectronIsMock } from '../../helpers/electron-mock.js'
+import { createElectronLogMock } from '../../helpers/electron-log-mock.js'
+
+vi.mock('electron-is', () => createElectronIsMock())
+vi.mock('electron-log', () => createElectronLogMock())
+
+const existsSync = vi.hoisted(() => vi.fn())
+const readFileSync = vi.hoisted(() => vi.fn())
+
+vi.mock('node:fs', () => ({
+  existsSync,
+  readFileSync
+}))
+
+const { parseEnginePortsFromConfig, readGoed2kdEnginePortsFromConfigSync } =
+  await import('../../../src/main/core/Goed2kdEngine.js')
+
+describe('parseEnginePortsFromConfig', () => {
+  it('返回默认端口', () => {
+    expect(parseEnginePortsFromConfig(null)).toEqual({
+      listenPort: GOED2KD_DEFAULT_LISTEN_TCP_PORT,
+      udpPort: GOED2KD_DEFAULT_LISTEN_UDP_PORT
+    })
+  })
+
+  it('解析 engine.listen_port 与 udp_port', () => {
+    expect(parseEnginePortsFromConfig({
+      engine: {
+        listen_port: 5000,
+        udp_port: 5001
+      }
+    })).toEqual({
+      listenPort: 5000,
+      udpPort: 5001
+    })
+  })
+
+  it('兼容 camelCase 字段', () => {
+    expect(parseEnginePortsFromConfig({
+      engine: {
+        listenPort: 6000,
+        udpPort: 6001
+      }
+    })).toEqual({
+      listenPort: 6000,
+      udpPort: 6001
+    })
+  })
+})
+
+describe('readGoed2kdEnginePortsFromConfigSync', () => {
+  beforeEach(() => {
+    existsSync.mockReset()
+    readFileSync.mockReset()
+  })
+
+  it('配置文件不存在时返回默认端口', () => {
+    existsSync.mockReturnValue(false)
+    expect(readGoed2kdEnginePortsFromConfigSync('/tmp/missing.json')).toEqual({
+      listenPort: GOED2KD_DEFAULT_LISTEN_TCP_PORT,
+      udpPort: GOED2KD_DEFAULT_LISTEN_UDP_PORT
+    })
+  })
+
+  it('从配置文件读取端口', () => {
+    existsSync.mockReturnValue(true)
+    readFileSync.mockReturnValue(JSON.stringify({
+      engine: { listen_port: 4665, udp_port: 4666 }
+    }))
+
+    expect(readGoed2kdEnginePortsFromConfigSync('/tmp/goed2kd.json')).toEqual({
+      listenPort: 4665,
+      udpPort: 4666
+    })
+  })
+
+  it('JSON 解析失败时回退默认端口', () => {
+    existsSync.mockReturnValue(true)
+    readFileSync.mockReturnValue('{bad-json')
+
+    expect(readGoed2kdEnginePortsFromConfigSync('/tmp/bad.json')).toEqual({
+      listenPort: GOED2KD_DEFAULT_LISTEN_TCP_PORT,
+      udpPort: GOED2KD_DEFAULT_LISTEN_UDP_PORT
+    })
+  })
+})

--- a/tests/main/core/ProtocolManager.test.js
+++ b/tests/main/core/ProtocolManager.test.js
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ADD_TASK_TYPE } from '@shared/constants'
+import { createElectronIsMock, createElectronMock } from '../../helpers/electron-mock.js'
+import { createElectronLogMock } from '../../helpers/electron-log-mock.js'
+
+const execFile = vi.hoisted(() => vi.fn())
+
+vi.mock('node:child_process', () => ({
+  execFile
+}))
+
+vi.mock('electron', () => createElectronMock())
+vi.mock('electron-is', () => createElectronIsMock({ dev: () => false, mas: () => false, windows: () => false }))
+vi.mock('electron-log', () => createElectronLogMock())
+
+const { default: ProtocolManager } = await import('../../../src/main/core/ProtocolManager.js')
+
+describe('ProtocolManager', () => {
+  let sendCommandToAll
+
+  beforeEach(() => {
+    sendCommandToAll = vi.fn()
+    global.application = { sendCommandToAll }
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    delete global.application
+  })
+
+  it('handleResourceProtocol 发送 new-task 命令', () => {
+    const manager = new ProtocolManager({ protocols: {} })
+    manager.handleResourceProtocol('magnet:?xt=urn:btih:abc')
+
+    expect(sendCommandToAll).toHaveBeenCalledWith('application:new-task', {
+      type: ADD_TASK_TYPE.URI,
+      uri: 'magnet:?xt=urn:btih:abc'
+    })
+  })
+
+  it('handleMoProtocol 解析 mo 协议命令', () => {
+    const manager = new ProtocolManager({ protocols: {} })
+    manager.handleMoProtocol('mo://preferences?foo=bar')
+
+    expect(sendCommandToAll).toHaveBeenCalledWith(
+      'application:preferences',
+      expect.objectContaining({ foo: 'bar' })
+    )
+  })
+
+  it('handle 根据协议类型分发', () => {
+    const manager = new ProtocolManager({ protocols: {} })
+    const resourceSpy = vi.spyOn(manager, 'handleResourceProtocol')
+    const moSpy = vi.spyOn(manager, 'handleMoProtocol')
+
+    manager.handle('https://example.com/file.zip')
+    manager.handle('mo://new-task')
+
+    expect(resourceSpy).toHaveBeenCalled()
+    expect(moSpy).toHaveBeenCalled()
+  })
+
+  it('queryRegDefaultValue 根据 reg 输出判断', async () => {
+    const manager = new ProtocolManager({ protocols: {} })
+    vi.spyOn(manager, 'runReg').mockResolvedValue('imFile.torrent default')
+
+    await expect(manager.queryRegDefaultValue('HKCU\\Software\\Classes\\.torrent')).resolves.toBe(true)
+  })
+})

--- a/tests/main/core/UPnPManager.test.js
+++ b/tests/main/core/UPnPManager.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createElectronLogMock } from '../../helpers/electron-log-mock.js'
+
+vi.mock('@achingbrain/nat-port-mapper', () => ({
+  upnpNat: vi.fn(),
+  pmpNat: vi.fn()
+}))
+
+vi.mock('default-gateway', () => ({
+  gateway4sync: vi.fn()
+}))
+
+vi.mock('electron-log', () => createElectronLogMock())
+
+const { default: UPnPManager } = await import('../../../src/main/core/UPnPManager.js')
+
+describe('UPnPManager', () => {
+  it('getPortMappingStatus 反映各端口映射状态', () => {
+    const manager = new UPnPManager()
+    const status = manager.getPortMappingStatus(6881, 6882, 4661, 4662)
+    expect(status).toEqual({
+      btMapped: false,
+      dhtMapped: false,
+      ed2kTcpMapped: false,
+      ed2kUdpMapped: false
+    })
+  })
+
+  it('getLocalHostForMap 无网关时返回局域网 IPv4', () => {
+    const manager = new UPnPManager()
+    const host = manager.getLocalHostForMap()
+    expect(host).toMatch(/^\d+\.\d+\.\d+\.\d+$|^::1$/)
+  })
+
+  it('_map 未指定端口时抛出错误', async () => {
+    const manager = new UPnPManager()
+    await expect(manager.map()).rejects.toThrow('[imFile] port was not specified')
+  })
+
+  it('_unmap 未映射端口时直接返回', async () => {
+    const manager = new UPnPManager()
+    await expect(manager.unmap(9999)).resolves.toBeUndefined()
+  })
+})

--- a/tests/main/core/UpdateManager.test.js
+++ b/tests/main/core/UpdateManager.test.js
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { PROXY_SCOPES } from '@shared/constants'
+import { createElectronIsMock, createElectronMock } from '../../helpers/electron-mock.js'
+import { createElectronLogMock } from '../../helpers/electron-log-mock.js'
+
+const autoUpdaterMock = vi.hoisted(() => ({
+  autoDownload: true,
+  autoInstallOnAppQuit: false,
+  logger: { log: vi.fn(), warn: vi.fn() },
+  netSession: { setProxy: vi.fn() },
+  signals: { login: vi.fn() },
+  on: vi.fn(),
+  checkForUpdates: vi.fn(),
+  downloadUpdate: vi.fn(),
+  quitAndInstall: vi.fn()
+}))
+
+vi.mock('electron-updater', () => ({
+  autoUpdater: autoUpdaterMock
+}))
+
+vi.mock('electron', () => createElectronMock())
+vi.mock('electron-is', () => createElectronIsMock({ dev: () => true }))
+vi.mock('electron-log', () => createElectronLogMock())
+vi.mock('../../../src/main/ui/Locale', () => ({
+  getI18n: () => ({ t: (key) => key })
+}))
+
+const { default: UpdateManager } = await import('../../../src/main/core/UpdateManager.js')
+
+describe('UpdateManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const createManager = (overrides = {}) => new UpdateManager({
+    autoCheck: false,
+    proxy: { enable: false },
+    ...overrides
+  })
+
+  it('resolveUpdateErrorMessageKey 映射 DNS 错误', () => {
+    const manager = createManager()
+    expect(manager.resolveUpdateErrorMessageKey(new Error('ERR_NAME_NOT_RESOLVED'))).toBe('app.update-error-dns')
+  })
+
+  it('resolveUpdateErrorMessageKey 映射超时错误', () => {
+    const manager = createManager()
+    expect(manager.resolveUpdateErrorMessageKey(new Error('ERR_CONNECTION_TIMED_OUT'))).toBe('app.update-error-timeout')
+  })
+
+  it('resolveUpdateErrorMessageKey 映射校验失败', () => {
+    const manager = createManager()
+    expect(manager.resolveUpdateErrorMessageKey(new Error('checksum mismatch'))).toBe('app.update-error-checksum')
+  })
+
+  it('resolveUpdateErrorMessageKey 未知错误', () => {
+    const manager = createManager()
+    expect(manager.resolveUpdateErrorMessageKey(new Error('something weird'))).toBe('app.update-error-unknown')
+  })
+
+  it('setupProxy 在 scope 包含 update-app 时设置代理', () => {
+    createManager({
+      proxy: {
+        enable: true,
+        server: 'http://127.0.0.1:7890',
+        scope: [PROXY_SCOPES.UPDATE_APP]
+      }
+    })
+    expect(autoUpdaterMock.netSession.setProxy).toHaveBeenCalledWith({
+      proxyRules: 'http://127.0.0.1:7890'
+    })
+  })
+
+  it('setupProxy 未启用时清除代理', () => {
+    createManager({ proxy: { enable: false } })
+    expect(autoUpdaterMock.netSession.setProxy).toHaveBeenCalledWith({
+      proxyRules: undefined
+    })
+  })
+
+  it('check 标记为用户主动检查', () => {
+    const manager = createManager()
+    manager.check()
+    expect(manager.autoCheckData.userCheck).toBe(true)
+    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

补充第五批单元测试，覆盖主进程 `main/core` 中此前无测试的核心模块。

### 新增测试文件

| 文件 | 覆盖模块 |
|------|---------|
| `Goed2kdEngine.test.js` | `parseEnginePortsFromConfig`、配置文件端口读取 |
| `ProtocolManager.test.js` | 协议 URL 分发、mo 命令解析 |
| `EnergyManager.test.js` | 节能阻止器启停 |
| `AutoLaunchManager.test.js` | 开机启动设置 |
| `EngineClient.test.js` | aria2 RPC 连接、call/shutdown |
| `UpdateManager.test.js` | 更新错误映射、代理配置 |
| `UPnPManager.test.js` | 端口映射状态、参数校验 |
| `Engine.test.js` | `shouldRunMigrateFromAria2`、`isRunning` |
| `Context.test.js` | 上下文初始化与键读写 |

### 辅助变更

- `tests/helpers/electron-log-mock.js`：统一主进程测试的 electron-log mock

### 覆盖率变化

- 测试用例：**302 → 342**（全部通过）

### Checklist

* [x] `pnpm run lint` 通过
* [x] `pnpm run test` 全部通过
* [ ] 未改动业务代码

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ba293e0-5537-4e8d-9e69-a2241ea4eed7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ba293e0-5537-4e8d-9e69-a2241ea4eed7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

