### PR TITLE
chore(release): 发布 v2.2.1，升级 go-aria2 至 v0.3.0

### DIFF
--- a/ChangeLog-CN.md
+++ b/ChangeLog-CN.md
@@ -1,3 +1,4 @@
+- 升级 go-aria2 下载内核至 v0.3.0（aria2 选项语义兼容、aria2-compat-mode 与 session 双写、bt-request-peer-speed-limit、file:// 本地文件下载、BT 校验进度、session FTP/SFTP 互换等）
 - 升级 go-aria2 下载内核至 v0.2.1（FTP/SFTP 限速与热更新、ED2K 迁移至 goed2k/core、补齐 saveSession/removeDownloadResult 等 RPC、修复 bt-max-peers 热更新等）
 - 升级 go-aria2 下载内核至 v0.1.1（addUri/addTorrent 支持 position 入队、getGlobalStat 增加 numStoppedTotal、新增 forceShutdown 别名等）
 - 任务页增加搜索入口并修复 Tab 与路由同步

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imFile",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A full-featured download manager",
   "homepage": "https://github.com/imfile-io/imfile-desktop",
   "author": {

--- a/scripts/sync-go-aria2.mjs
+++ b/scripts/sync-go-aria2.mjs
@@ -45,8 +45,8 @@ const FOLDER_TO_GO = {
   }
 }
 
-/** 默认同步的 go-aria2 版本；可通过环境变量 GO_ARIA2_VERSION 覆盖（如 v0.2.1） */
-const GO_ARIA2_VERSION = process.env.GO_ARIA2_VERSION || 'v0.2.1'
+/** 默认同步的 go-aria2 版本；可通过环境变量 GO_ARIA2_VERSION 覆盖（如 v0.3.0） */
+const GO_ARIA2_VERSION = process.env.GO_ARIA2_VERSION || 'v0.3.0'
 
 function releaseApiUrl (version) {
   const tag = version.startsWith('v') ? version : `v${version}`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

上游 [chenjia404/go-aria2 v0.3.0](https://github.com/chenjia404/go-aria2/releases/tag/v0.3.0) 已发布，本次将 imFile 内置下载内核同步升级，并发布应用版本 **v2.2.1**。

## 变更内容

| 文件 | 变更 |
|------|------|
| `scripts/sync-go-aria2.mjs` | 默认同步版本 `v0.2.1` → `v0.3.0` |
| `package.json` | 应用版本 `2.2.0` → `2.2.1` |
| `ChangeLog-CN.md` | 记录 go-aria2 v0.3.0 升级说明 |

## go-aria2 v0.3.0 主要新特性

- **Phase A**：aria2 选项语义兼容落地
- **Phase B/C**：`aria2-compat-mode` 与 session 双写
- **Phase D**：`bt-request-peer-speed-limit` 与 `getGlobalOption` 补齐
- **Phase E**：`file://` URI 本地文件下载
- **Phase F**：BT 校验进度与 session FTP/SFTP 互换

## 验证

- [x] `pnpm run sync-go-aria2` 成功拉取 v0.3.0 二进制（6/7 平台，win32/ia32 仍无上游资源）
- [x] `pnpm run test` — 52 个测试文件、342 个用例全部通过

## 发布说明

合并后请推送 tag `v2.2.1` 以触发 GitHub Actions Build/release 工作流进行多平台打包与发布。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64a8ac6d-bc29-46bf-9687-4676e94f5b8d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64a8ac6d-bc29-46bf-9687-4676e94f5b8d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

