### PR TITLE
fix(ci): 对齐 Renovate 与 pnpm minimumReleaseAge 策略

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,9 @@ allowBuilds:
   esbuild: true
   unrs-resolver: true
 
+# pnpm 11 默认 1440 分钟（1 天）；显式声明以便与 Renovate minimumReleaseAge 对齐
+minimumReleaseAge: 1440
+
 minimumReleaseAgeExclude:
   - postcss
   - axios@1.19.0

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,9 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-      "config:base"
-    ],
-    "forkProcessing": "enabled"
-  }
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "forkProcessing": "enabled",
+  "minimumReleaseAge": "1 day",
+  "internalChecksFilter": "strict"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

多个 Renovate 依赖升级 PR 在 CI 的 `pnpm install --frozen-lockfile` 阶段失败：

```
ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION
eslint@10.8.1 was published at ..., within the minimumReleaseAge cutoff
```

根因是 **pnpm 11 默认要求 lockfile 中的包发布超过 24 小时**，而 Renovate 在包发布后立即创建 PR，导致 CI 拒绝尚未满龄的 lockfile 条目。

受影响的 PR 包括：#426 (ws)、#428 (vue)、#430 (element-plus)、#431 (happy-dom)、#432 (eslint)。

## 修复

1. **renovate.json**：新增 `minimumReleaseAge: "1 day"` 与 `internalChecksFilter: "strict"`，使 Renovate 在依赖满 1 天后再创建/更新 PR
2. **pnpm-workspace.yaml**：显式声明 `minimumReleaseAge: 1440`（分钟），与 pnpm 默认策略及 Renovate 配置对齐

## 验证

- 本地 `pnpm install --frozen-lockfile`、`pnpm run lint`、`pnpm run test` 均通过
- master 分支 CI 行为不变

## 后续

- 已存在的失败 Renovate PR 在依赖满龄后重新触发 CI 即可通过
- 未来 Renovate PR 将延迟至包发布满 1 天后才出现，避免同类 CI 失败
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31ff3180-f852-4e32-81ec-d9f7d87bff1d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31ff3180-f852-4e32-81ec-d9f7d87bff1d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

