### PR TITLE
fix(dev): 修复 Windows 下 electron-vite 开发模式只显示骨架无文字

### DIFF
--- a/src/main/configs/page.js
+++ b/src/main/configs/page.js
@@ -12,13 +12,31 @@ function useRendererDevServer () {
   return !app.isPackaged && process.env.NODE_ENV !== 'production' && is.dev()
 }
 
-const indexLoad = useRendererDevServer()
-  ? { url: 'http://localhost:9080/index.html' }
-  : {
-      // 打包后 app.getAppPath() 指向 app.asar 根目录；开发时指向仓库根目录。
-      // 渲染产物始终位于 dist/electron/index.html，不能依赖当前源码模块的 __dirname。
-      htmlFile: path.join(app.getAppPath(), 'dist', 'electron', 'index.html')
-    }
+/**
+ * electron-vite dev 会注入 ELECTRON_RENDERER_URL（如 http://localhost:5173）；
+ * 勿硬编码 webpack dev-server 的 9080，否则默认 pnpm run dev 在 Windows 等环境只显示骨架屏、无界面文字。
+ */
+export function getRendererDevServerUrl () {
+  const fromElectronVite = process.env.ELECTRON_RENDERER_URL
+  if (fromElectronVite) {
+    const base = fromElectronVite.replace(/\/$/, '')
+    return `${base}/`
+  }
+  return 'http://localhost:9080/index.html'
+}
+
+export function resolveIndexLoad () {
+  if (useRendererDevServer()) {
+    return { url: getRendererDevServerUrl() }
+  }
+  // 打包后 app.getAppPath() 指向 app.asar 根目录；开发时指向仓库根目录。
+  // 渲染产物始终位于 dist/electron/index.html，不能依赖当前源码模块的 __dirname。
+  return {
+    htmlFile: path.join(app.getAppPath(), 'dist', 'electron', 'index.html')
+  }
+}
+
+const indexLoad = resolveIndexLoad()
 
 export default {
   index: {

--- a/src/renderer/components/Theme/Default.scss
+++ b/src/renderer/components/Theme/Default.scss
@@ -10,6 +10,7 @@ body {
     'Microsoft YaHei', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-variant: tabular-nums;
   font-size: $--font-size-medium;
+  color: $--color-text-primary;
 }
 
 ::-webkit-scrollbar {
@@ -303,6 +304,7 @@ iframe {
         display: inline-block;
         vertical-align: middle;
         font-size: 14px;
+        color: $--subnav-text-color;
       }
 
       &:hover,

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="zh-CN" class="theme-light">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/renderer/pages/index/App.vue
+++ b/src/renderer/pages/index/App.vue
@@ -84,8 +84,8 @@ export default {
       const { themeClass = '', i18nClass = '', directionClass = '' } = this
       const classList = [themeClass, i18nClass, directionClass]
 
-      // Element Plus dark vars uses `.dark`; keep compatibility with existing `theme-dark`.
-      if (themeClass === `theme-${APP_THEME.DARK}`) {
+      // Element Plus dark vars uses `.dark`; AUTO 跟随系统时 class 为 theme-dark，也需同步 dark。
+      if (themeClass.includes('dark')) {
         classList.push('dark')
       }
 

--- a/src/renderer/pages/index/main.js
+++ b/src/renderer/pages/index/main.js
@@ -93,5 +93,6 @@ store.dispatch('preference/fetchPreference')
     init(config)
   })
   .catch((err) => {
-    alert(err)
+    console.error('[imFile] load preference failed, fallback to defaults:', err)
+    init({})
   })

--- a/tests/main/configs/page.test.js
+++ b/tests/main/configs/page.test.js
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const mockApp = {
+  isPackaged: false,
+  getAppPath: vi.fn(() => '/mock/app')
+}
+
+const mockIsDev = vi.fn(() => true)
+
+vi.mock('electron', () => ({
+  app: mockApp
+}))
+
+vi.mock('electron-is', () => ({
+  default: {
+    dev: () => mockIsDev(),
+    macOS: () => false
+  }
+}))
+
+describe('main/configs/page', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    mockApp.isPackaged = false
+    mockIsDev.mockReturnValue(true)
+    vi.resetModules()
+  })
+
+  it('electron-vite dev 优先使用 ELECTRON_RENDERER_URL', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    vi.stubEnv('ELECTRON_RENDERER_URL', 'http://127.0.0.1:5173')
+
+    const { getRendererDevServerUrl, resolveIndexLoad } = await import('../../../src/main/configs/page.js')
+
+    expect(getRendererDevServerUrl()).toBe('http://127.0.0.1:5173/')
+    expect(resolveIndexLoad()).toEqual({ url: 'http://127.0.0.1:5173/' })
+  })
+
+  it('webpack dev-server 回退到 9080', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    delete process.env.ELECTRON_RENDERER_URL
+
+    const { getRendererDevServerUrl } = await import('../../../src/main/configs/page.js')
+
+    expect(getRendererDevServerUrl()).toBe('http://localhost:9080/index.html')
+  })
+
+  it('已打包应用走本地 index.html', async () => {
+    mockApp.isPackaged = true
+    vi.stubEnv('NODE_ENV', 'development')
+
+    const { resolveIndexLoad } = await import('../../../src/main/configs/page.js')
+
+    expect(resolveIndexLoad()).toEqual({
+      htmlFile: '/mock/app/dist/electron/index.html'
+    })
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

在 Windows 上使用默认的 `pnpm run dev`（electron-vite）启动时，主窗口往往只有彩色骨架屏，没有侧栏文字、任务列表等界面内容，表现为「看不到文字」。

## 原因

构建体系已迁移到 electron-vite，开发时渲染进程由 Vite 提供，并通过 `ELECTRON_RENDERER_URL`（如 `http://localhost:5173`）注入主进程。但 `page.js` 仍硬编码 webpack dev-server 的 `http://localhost:9080/index.html`，9080 无服务时脚本 404，Vue 无法挂载。

若使用 **v2.3.0/v2.3.1 正式安装包** 出现类似现象，多为 #439 已修复的生产白屏问题，请升级到 **v2.3.2** 或更高版本。

## 改动

- `page.js`：优先使用 `ELECTRON_RENDERER_URL`，webpack 开发路径回退 9080
- `index.html`：默认 `theme-light`，改善首屏文字对比度
- `Default.scss`：为 `body` 与侧栏文字显式设置颜色
- `App.vue`：`theme-dark`（含自动跟随系统）时同步 Element Plus `dark` 类
- `main.js`：偏好加载失败时用默认配置启动，避免永久停留在骨架屏

## 测试

- 新增 `tests/main/configs/page.test.js`
- 全量单元测试通过（348 tests）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16e99603-f844-414b-b66e-3ad014f39c3f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16e99603-f844-414b-b66e-3ad014f39c3f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

