### PR TITLE
fix(win): 修复安装包与开发模式下界面文字不显示

### DIFF
--- a/.electron-vue/webpack.renderer.config.mjs
+++ b/.electron-vue/webpack.renderer.config.mjs
@@ -213,10 +213,15 @@ const rendererConfig = {
       : {
           module: true,
           chunkFormat: 'module',
+          chunkLoading: 'import',
           environment: { module: true, dynamicImport: true }
         }),
-    /** 生产 file:// 用相对路径；开发保持 / 以免 dev server / HMR 异常 */
-    publicPath: devMode ? '/' : './'
+    /**
+     * 生产 Electron file:// 下懒加载 chunk 须用 publicPath:'auto'（基于 import.meta.url），
+     * 勿用 './'：webpack 会拼成 file:///C:/.../102.js 等非法 URL，路由动态 import 失败，
+     * 表现为安装包启动后仅标题栏/骨架、主区域无文字（#439 仅修复了入口 index.js）。
+     */
+    publicPath: devMode ? '/' : 'auto'
   },
   resolve: {
     alias: {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,11 +79,19 @@ jobs:
       - name: Build application (webpack)
         run: pnpm run build:github
 
-      # 构建失败时上面一步已非零退出；此处再断言关键产物，避免「空目录也通过」的误判。
       - name: 验证构建产物
         run: |
           set -e
           test -f dist/electron/main.js
           test -f dist/electron/index.html
           test -f dist/electron/package.json
-          echo "OK: dist/electron/main.js、index.html 与 package.json 已生成。"
+          # electron-vite：index.html 须为相对路径；webpack：bundle 须为 publicPath:auto
+          if grep -qE 'src="\./assets/' dist/electron/index.html; then
+            echo "OK: electron-vite 渲染产物使用相对路径 ./assets/"
+          elif grep -q 'Automatic publicPath' dist/electron/index.js; then
+            echo "OK: webpack 渲染 bundle 使用 publicPath:auto"
+          else
+            echo "ERROR: 渲染产物路径异常，Electron file:// 下可能无法加载脚本或懒加载 chunk"
+            exit 1
+          fi
+          echo "OK: dist/electron 关键产物已生成。"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

Windows **正式安装包**（v2.3.2 等）启动后常见现象：

- 有窗口、彩色骨架或标题栏
- **侧栏/任务列表等文字不显示**，主区域空白

## 根因（比 #439 更深一层）

1. **#439** 修复了入口脚本 `publicPath: '/'` → 相对路径，使 `index.js` 能加载。
2. Release 工作流仍使用 **webpack**（`build.mjs`）打包，路由对 `Main.vue`、`Task/Index.vue` 等大量使用 **动态 `import()`**。
3. webpack 生产配置使用 `publicPath: './'` + `outputModule` 时，懒加载 chunk 通过 `publicPath + filename` 拼接 URL，在 Electron **`file://`** 下会生成非法本地资源路径，动态 import 失败。
4. 入口 JS 已执行，但 `router-view` 对应的 chunk 拉不下来，界面就像「没有文字」。

开发模式 `pnpm run dev` 另有独立问题：主进程仍指向 9080 而非 electron-vite 的 `ELECTRON_RENDERER_URL`（本 PR 已一并修复）。

## 改动

- **webpack.renderer.config.mjs**：生产环境 `publicPath: 'auto'` + `chunkLoading: 'import'`（基于 `import.meta.url` 加载 chunk）
- **page.js**：dev 优先 `ELECTRON_RENDERER_URL`
- **渲染层**：首屏 `theme-light`、正文/侧栏显式文字色、偏好加载失败时降级启动
- **CI**：校验构建产物路径，防止回退

## 验证

- 单元测试 348 项通过
- 本地 webpack 生产构建后 bundle 不再包含 `u.p+u.u`，含 `Automatic publicPath`

## 用户侧

需等待包含本修复的版本 **重新打包发布**（当前 GitHub 上的 v2.3.2 安装包不含此修复）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16e99603-f844-414b-b66e-3ad014f39c3f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16e99603-f844-414b-b66e-3ad014f39c3f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

