### PR TITLE
docs: 修复 README 中失效的 Star History 图表

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -145,7 +145,7 @@ pnpm run build:applesilicon
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=imfile-io/imfile-desktop&type=Timeline)](https://star-history.com/#imfile-io/imfile-desktop&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=imfile-io/imfile-desktop&type=Timeline)](https://star-history.dera.page/#imfile-io/imfile-desktop&Timeline)
 
 ## 📜 开源许可
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ After building, the application will be found in the project's `release` directo
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=imfile-io/imfile-desktop&type=Timeline)](https://star-history.com/#imfile-io/imfile-desktop&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=imfile-io/imfile-desktop&type=Timeline)](https://star-history.dera.page/#imfile-io/imfile-desktop&Timeline)
 
 ## 📜 License
 


### PR DESCRIPTION
当前 README 中的 Star History 图表因 GitHub stargazer API 限制已经失效。

本次更新将图表和链接切换到可用的新数据源，让仓库的 Star 趋势图能够重新正常显示。