### PR TITLE
fix(portable): 纠正便携迁移后残留的 AppData DHT 路径 (#407)

### DIFF
--- a/src/main/core/ConfigManager.js
+++ b/src/main/core/ConfigManager.js
@@ -10,6 +10,11 @@ import {
   getUserDownloadsPath
 } from '../utils/index'
 import {
+  collectPortableDhtPathFixes,
+  isPathInsideDir
+} from '../utils/portableDhtPaths'
+import { reclaimLegacyDhtFiles } from '../utils/portableLegacyCleanup'
+import {
   APP_RUN_MODE,
   APP_THEME,
   EMPTY_STRING,
@@ -179,6 +184,7 @@ export default class ConfigManager {
 
     if (isPortableMode()) {
       this.fixPortableDownloadDir()
+      this.fixPortableDhtPaths()
     }
   }
 
@@ -215,6 +221,47 @@ export default class ConfigManager {
       }
     } catch {
       // 保留用户原设置
+    }
+  }
+
+  /**
+   * 便携模式下强制将 dht-file-path / dht-file-path6 改到程序目录。
+   * 从 AppData 迁移的 system.json 会带上旧绝对路径，electron-store 不会覆盖已有键，
+   * 引擎会持续向 %APPDATA%\\imFile 写入 dht.dat，空目录清理因此失效。
+   */
+  fixPortableDhtPaths () {
+    const portableRoot = getPortableExecutableDir()
+    if (!portableRoot) {
+      return
+    }
+
+    const fixes = collectPortableDhtPathFixes({
+      'dht-file-path': this.systemConfig.get('dht-file-path'),
+      'dht-file-path6': this.systemConfig.get('dht-file-path6')
+    }, portableRoot)
+
+    const previousPaths = []
+    for (const { key, from, to } of fixes) {
+      this.setSystemConfig(key, to)
+      if (from) {
+        previousPaths.push(from)
+      }
+    }
+
+    const legacyDir = this.getLegacyUserDataDir()
+    const overwrite = previousPaths.some((p) => isPathInsideDir(p, legacyDir))
+    reclaimLegacyDhtFiles(legacyDir, portableRoot, {
+      overwrite,
+      extraPaths: previousPaths
+    })
+  }
+
+  getLegacyUserDataDir () {
+    try {
+      const appName = typeof app.getName === 'function' ? app.getName() : 'imFile'
+      return resolve(app.getPath('appData'), appName || 'imFile')
+    } catch {
+      return ''
     }
   }
 

--- a/src/main/portable-userdata.js
+++ b/src/main/portable-userdata.js
@@ -9,7 +9,8 @@
 import { cpSync, existsSync, readdirSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { app } from 'electron'
-import { removeEmptyLegacyUserDataDir } from './utils/portableLegacyCleanup'
+import { isPathInsideDir, rewritePortableDhtPathsInSystemJson } from './utils/portableDhtPaths'
+import { reclaimLegacyDhtFiles, removeEmptyLegacyUserDataDir } from './utils/portableLegacyCleanup'
 
 const PORTABLE_DATA_FILES = new Set([
   'user.json',
@@ -138,5 +139,17 @@ if (portableRoot) {
   app.setPath('userData', portableRoot)
   app.setPath('logs', join(portableRoot, 'logs'))
   app.setPath('cache', getPortableCacheDir(portableRoot))
+
+  // 迁移会原样复制 system.json；其中 dht-file-path / dht-file-path6
+  // 仍是 AppData 绝对路径，electron-store 不会用 defaults 覆盖已有键。
+  const { previousPaths } = rewritePortableDhtPathsInSystemJson(
+    join(portableRoot, 'system.json'),
+    portableRoot
+  )
+  const overwriteLegacyDht = previousPaths.some((p) => isPathInsideDir(p, defaultUserData))
+  reclaimLegacyDhtFiles(defaultUserData, portableRoot, {
+    overwrite: overwriteLegacyDht,
+    extraPaths: previousPaths
+  })
   removeEmptyLegacyUserDataDir(defaultUserData)
 }

--- a/src/main/utils/portableDhtPaths.js
+++ b/src/main/utils/portableDhtPaths.js
@@ -1,0 +1,108 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { resolve, sep } from 'node:path'
+
+export const PORTABLE_DHT_PATH_KEYS = [
+  ['dht-file-path', 'dht.dat'],
+  ['dht-file-path6', 'dht6.dat']
+]
+
+export function isSameFilePath (left, right) {
+  if (!left || !right) {
+    return false
+  }
+  try {
+    const a = resolve(String(left))
+    const b = resolve(String(right))
+    if (process.platform === 'win32') {
+      return a.toLowerCase() === b.toLowerCase()
+    }
+    return a === b
+  } catch {
+    return false
+  }
+}
+
+export function isPathInsideDir (filePath, dir) {
+  if (!filePath || !dir) {
+    return false
+  }
+  try {
+    const resolvedFile = resolve(String(filePath))
+    const resolvedDir = resolve(String(dir))
+    if (isSameFilePath(resolvedFile, resolvedDir)) {
+      return true
+    }
+    const prefix = resolvedDir.endsWith(sep) ? resolvedDir : `${resolvedDir}${sep}`
+    if (process.platform === 'win32') {
+      return resolvedFile.toLowerCase().startsWith(prefix.toLowerCase())
+    }
+    return resolvedFile.startsWith(prefix)
+  } catch {
+    return false
+  }
+}
+
+export function getPortableDhtFilePath (portableRoot, fileName) {
+  return resolve(portableRoot, fileName)
+}
+
+/**
+ * 计算需要改写到便携根目录的 DHT 路径。
+ * electron-store 对已存在的键不会套用 defaults，迁移后的绝对路径会一直指向 AppData。
+ * @returns {{ key: string, from: string, to: string }[]}
+ */
+export function collectPortableDhtPathFixes (currentByKey, portableRoot) {
+  if (!currentByKey || !portableRoot) {
+    return []
+  }
+
+  const fixes = []
+  for (const [key, fileName] of PORTABLE_DHT_PATH_KEYS) {
+    const expected = getPortableDhtFilePath(portableRoot, fileName)
+    const current = currentByKey[key]
+    if (!current || !isSameFilePath(current, expected)) {
+      fixes.push({
+        key,
+        from: current ? String(current) : '',
+        to: expected
+      })
+    }
+  }
+  return fixes
+}
+
+/**
+ * 读取便携目录 system.json，将残留的 DHT 绝对路径改写为便携根目录。
+ * @returns {{ changed: boolean, previousPaths: string[] }}
+ */
+export function rewritePortableDhtPathsInSystemJson (systemJsonPath, portableRoot) {
+  const empty = { changed: false, previousPaths: [] }
+  if (!systemJsonPath || !portableRoot || !existsSync(systemJsonPath)) {
+    return empty
+  }
+
+  try {
+    const data = JSON.parse(readFileSync(systemJsonPath, 'utf8'))
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+      return empty
+    }
+
+    const fixes = collectPortableDhtPathFixes(data, portableRoot)
+    if (fixes.length === 0) {
+      return empty
+    }
+
+    const previousPaths = []
+    for (const { key, from, to } of fixes) {
+      data[key] = to
+      if (from) {
+        previousPaths.push(from)
+      }
+    }
+    writeFileSync(systemJsonPath, `${JSON.stringify(data, null, 2)}\n`)
+    return { changed: true, previousPaths }
+  } catch (err) {
+    console.warn('[imFile] 便携模式：重写 system.json DHT 路径失败', err)
+    return empty
+  }
+}

--- a/src/main/utils/portableLegacyCleanup.js
+++ b/src/main/utils/portableLegacyCleanup.js
@@ -1,4 +1,8 @@
-import { existsSync, readdirSync, rmSync } from 'node:fs'
+import { cpSync, existsSync, readdirSync, rmSync } from 'node:fs'
+import { basename, join, resolve } from 'node:path'
+import { isPathInsideDir, isSameFilePath } from './portableDhtPaths'
+
+const LEGACY_DHT_FILE_NAMES = new Set(['dht.dat', 'dht6.dat'])
 
 /**
  * 便携模式重定向 userData 后，移除 Electron 在 app.getPath('userData') 时
@@ -19,4 +23,70 @@ export function removeEmptyLegacyUserDataDir (legacyDir) {
   } catch (err) {
     console.warn('[imFile] 便携模式：清理 AppData 空目录失败', err)
   }
+}
+
+/**
+ * 回收 AppData 中残留的 dht.dat / dht6.dat。
+ * 迁移后若 system.json 仍指向旧绝对路径，引擎会持续写入这些文件，
+ * 导致目录非空、空目录清理永远不触发。
+ *
+ * overwrite=true 时用残留文件覆盖便携目录副本（引擎此前一直在往 AppData 写，残留文件更新）。
+ */
+export function reclaimLegacyDhtFiles (legacyDir, portableRoot, options = {}) {
+  const { overwrite = false, extraPaths = [] } = options
+  if (!portableRoot) {
+    return
+  }
+  if (legacyDir && isSameFilePath(legacyDir, portableRoot)) {
+    return
+  }
+
+  const targets = []
+  if (legacyDir) {
+    for (const name of LEGACY_DHT_FILE_NAMES) {
+      targets.push(join(legacyDir, name))
+    }
+  }
+  for (const extra of extraPaths) {
+    if (typeof extra === 'string' && extra) {
+      targets.push(extra)
+    }
+  }
+
+  const seen = new Set()
+  for (const src of targets) {
+    let normalized
+    try {
+      normalized = resolve(src)
+    } catch {
+      continue
+    }
+    if (seen.has(normalized)) {
+      continue
+    }
+    seen.add(normalized)
+
+    const name = basename(normalized)
+    if (!LEGACY_DHT_FILE_NAMES.has(name)) {
+      continue
+    }
+    if (!existsSync(normalized)) {
+      continue
+    }
+    if (isPathInsideDir(normalized, portableRoot)) {
+      continue
+    }
+
+    const dest = join(portableRoot, name)
+    try {
+      if (overwrite || !existsSync(dest)) {
+        cpSync(normalized, dest)
+      }
+      rmSync(normalized, { force: true })
+    } catch (err) {
+      console.warn('[imFile] 便携模式：回收 AppData DHT 文件失败', err)
+    }
+  }
+
+  removeEmptyLegacyUserDataDir(legacyDir)
 }

--- a/tests/helpers/electron-mock.js
+++ b/tests/helpers/electron-mock.js
@@ -14,6 +14,7 @@ export const createElectronMock = (overrides = {}) => {
       return paths[name] || `/mock/${name}`
     }),
     getAppPath: vi.fn(() => '/mock/app'),
+    getName: vi.fn(() => 'imFile'),
     getLocale: vi.fn(() => 'zh-CN'),
     getLoginItemSettings: vi.fn(() => ({ openAtLogin: false })),
     isPackaged: false,

--- a/tests/main/core/ConfigManager.test.js
+++ b/tests/main/core/ConfigManager.test.js
@@ -109,6 +109,36 @@ describe('ConfigManager', () => {
     expect(manager.getSystemConfig('dir')).toBe('/portable/Downloads')
   })
 
+  it('便携模式下将残留的 AppData DHT 路径改写到程序目录', () => {
+    process.env.PORTABLE_EXECUTABLE_DIR = '/portable'
+    manager.setSystemConfig('dht-file-path', '/mock/appData/imFile/dht.dat')
+    manager.setSystemConfig('dht-file-path6', '/mock/appData/imFile/dht6.dat')
+    manager.fixPortableDhtPaths()
+
+    expect(manager.getSystemConfig('dht-file-path')).toBe('/portable/dht.dat')
+    expect(manager.getSystemConfig('dht-file-path6')).toBe('/portable/dht6.dat')
+  })
+
+  it('便携模式下已指向程序目录的 DHT 路径保持不变', () => {
+    process.env.PORTABLE_EXECUTABLE_DIR = '/portable'
+    manager.setSystemConfig('dht-file-path', '/portable/dht.dat')
+    manager.setSystemConfig('dht-file-path6', '/portable/dht6.dat')
+    manager.fixPortableDhtPaths()
+
+    expect(manager.getSystemConfig('dht-file-path')).toBe('/portable/dht.dat')
+    expect(manager.getSystemConfig('dht-file-path6')).toBe('/portable/dht6.dat')
+  })
+
+  it('fixSystemConfig 在便携模式下同步纠正 DHT 路径', () => {
+    process.env.PORTABLE_EXECUTABLE_DIR = '/portable'
+    manager.setSystemConfig('dht-file-path', '/mock/appData/imFile/dht.dat')
+    manager.setSystemConfig('dht-file-path6', '/mock/appData/imFile/dht6.dat')
+    manager.fixSystemConfig()
+
+    expect(manager.getSystemConfig('dht-file-path')).toBe('/portable/dht.dat')
+    expect(manager.getSystemConfig('dht-file-path6')).toBe('/portable/dht6.dat')
+  })
+
   it('reset 清空用户与系统配置', () => {
     manager.setUserConfig('theme', APP_THEME.DARK)
     manager.setSystemConfig('pause', true)

--- a/tests/main/utils/portableDhtPaths.test.js
+++ b/tests/main/utils/portableDhtPaths.test.js
@@ -1,0 +1,127 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  collectPortableDhtPathFixes,
+  isPathInsideDir,
+  isSameFilePath,
+  rewritePortableDhtPathsInSystemJson
+} from '../../../src/main/utils/portableDhtPaths'
+
+const tempDirs = []
+
+function makeTempDir (prefix) {
+  const dir = join(tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`)
+  mkdirSync(dir, { recursive: true })
+  tempDirs.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('isSameFilePath / isPathInsideDir', () => {
+  it('识别相同路径', () => {
+    expect(isSameFilePath('/portable/dht.dat', '/portable/./dht.dat')).toBe(true)
+    expect(isSameFilePath('/portable/dht.dat', '/other/dht.dat')).toBe(false)
+    expect(isSameFilePath('', '/portable/dht.dat')).toBe(false)
+  })
+
+  it('识别目录包含关系', () => {
+    expect(isPathInsideDir('/appData/imFile/dht.dat', '/appData/imFile')).toBe(true)
+    expect(isPathInsideDir('/appData/imFile', '/appData/imFile')).toBe(true)
+    expect(isPathInsideDir('/portable/dht.dat', '/appData/imFile')).toBe(false)
+    expect(isPathInsideDir('/appData/imFile-extra/dht.dat', '/appData/imFile')).toBe(false)
+  })
+})
+
+describe('collectPortableDhtPathFixes', () => {
+  it('将 AppData 残留路径改写到便携根目录', () => {
+    const fixes = collectPortableDhtPathFixes({
+      'dht-file-path': 'C:\\Users\\User\\AppData\\Roaming\\imFile\\dht.dat',
+      'dht-file-path6': 'C:\\Users\\User\\AppData\\Roaming\\imFile\\dht6.dat'
+    }, '/portable')
+
+    expect(fixes).toEqual([
+      {
+        key: 'dht-file-path',
+        from: 'C:\\Users\\User\\AppData\\Roaming\\imFile\\dht.dat',
+        to: '/portable/dht.dat'
+      },
+      {
+        key: 'dht-file-path6',
+        from: 'C:\\Users\\User\\AppData\\Roaming\\imFile\\dht6.dat',
+        to: '/portable/dht6.dat'
+      }
+    ])
+  })
+
+  it('已指向便携目录时不改写', () => {
+    expect(collectPortableDhtPathFixes({
+      'dht-file-path': '/portable/dht.dat',
+      'dht-file-path6': '/portable/dht6.dat'
+    }, '/portable')).toEqual([])
+  })
+
+  it('空值或缺省键也会补到便携目录', () => {
+    const fixes = collectPortableDhtPathFixes({}, '/portable')
+    expect(fixes.map((item) => item.to)).toEqual([
+      '/portable/dht.dat',
+      '/portable/dht6.dat'
+    ])
+  })
+})
+
+describe('rewritePortableDhtPathsInSystemJson', () => {
+  it('重写 system.json 中的 DHT 绝对路径', () => {
+    const portableRoot = makeTempDir('imfile-portable-dht')
+    const systemJsonPath = join(portableRoot, 'system.json')
+    writeFileSync(systemJsonPath, JSON.stringify({
+      dir: '/portable/Downloads',
+      'dht-file-path': '/mock/appData/imFile/dht.dat',
+      'dht-file-path6': '/mock/appData/imFile/dht6.dat',
+      'save-session': '/portable/session.json'
+    }, null, 2))
+
+    const result = rewritePortableDhtPathsInSystemJson(systemJsonPath, portableRoot)
+
+    expect(result.changed).toBe(true)
+    expect(result.previousPaths).toEqual([
+      '/mock/appData/imFile/dht.dat',
+      '/mock/appData/imFile/dht6.dat'
+    ])
+
+    const written = JSON.parse(readFileSync(systemJsonPath, 'utf8'))
+    expect(written['dht-file-path']).toBe(join(portableRoot, 'dht.dat'))
+    expect(written['dht-file-path6']).toBe(join(portableRoot, 'dht6.dat'))
+    expect(written['save-session']).toBe('/portable/session.json')
+  })
+
+  it('路径已正确时不改写文件', () => {
+    const portableRoot = makeTempDir('imfile-portable-dht-ok')
+    const systemJsonPath = join(portableRoot, 'system.json')
+    const payload = {
+      'dht-file-path': join(portableRoot, 'dht.dat'),
+      'dht-file-path6': join(portableRoot, 'dht6.dat')
+    }
+    writeFileSync(systemJsonPath, JSON.stringify(payload))
+
+    const result = rewritePortableDhtPathsInSystemJson(systemJsonPath, portableRoot)
+    expect(result.changed).toBe(false)
+    expect(JSON.parse(readFileSync(systemJsonPath, 'utf8'))).toEqual(payload)
+  })
+
+  it('缺少 system.json 时静默跳过', () => {
+    const portableRoot = makeTempDir('imfile-portable-dht-missing')
+    const result = rewritePortableDhtPathsInSystemJson(
+      join(portableRoot, 'system.json'),
+      portableRoot
+    )
+    expect(result).toEqual({ changed: false, previousPaths: [] })
+    expect(existsSync(join(portableRoot, 'system.json'))).toBe(false)
+  })
+})

--- a/tests/main/utils/portableLegacyCleanup.test.js
+++ b/tests/main/utils/portableLegacyCleanup.test.js
@@ -1,8 +1,11 @@
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { describe, expect, it } from 'vitest'
-import { removeEmptyLegacyUserDataDir } from '../../../src/main/utils/portableLegacyCleanup'
+import {
+  reclaimLegacyDhtFiles,
+  removeEmptyLegacyUserDataDir
+} from '../../../src/main/utils/portableLegacyCleanup'
 
 describe('removeEmptyLegacyUserDataDir', () => {
   it('移除空目录', () => {
@@ -34,5 +37,61 @@ describe('removeEmptyLegacyUserDataDir', () => {
   it('忽略空路径', () => {
     expect(() => removeEmptyLegacyUserDataDir('')).not.toThrow()
     expect(() => removeEmptyLegacyUserDataDir(null)).not.toThrow()
+  })
+})
+
+describe('reclaimLegacyDhtFiles', () => {
+  it('overwrite 时把 AppData 残留 DHT 文件迁到便携目录并删除旧文件', () => {
+    const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`
+    const legacyDir = join(tmpdir(), `imfile-legacy-dht-${stamp}`)
+    const portableRoot = join(tmpdir(), `imfile-portable-dht-${stamp}`)
+    mkdirSync(legacyDir, { recursive: true })
+    mkdirSync(portableRoot, { recursive: true })
+    writeFileSync(join(legacyDir, 'dht.dat'), 'legacy-v4')
+    writeFileSync(join(legacyDir, 'dht6.dat'), 'legacy-v6')
+    writeFileSync(join(portableRoot, 'dht.dat'), 'stale-v4')
+
+    reclaimLegacyDhtFiles(legacyDir, portableRoot, { overwrite: true })
+
+    expect(existsSync(join(legacyDir, 'dht.dat'))).toBe(false)
+    expect(existsSync(join(legacyDir, 'dht6.dat'))).toBe(false)
+    expect(readFileSync(join(portableRoot, 'dht.dat'), 'utf8')).toBe('legacy-v4')
+    expect(readFileSync(join(portableRoot, 'dht6.dat'), 'utf8')).toBe('legacy-v6')
+    expect(existsSync(legacyDir)).toBe(false)
+    rmSync(portableRoot, { recursive: true, force: true })
+  })
+
+  it('不覆盖便携目录中已有的 DHT 文件', () => {
+    const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`
+    const legacyDir = join(tmpdir(), `imfile-legacy-dht-keep-${stamp}`)
+    const portableRoot = join(tmpdir(), `imfile-portable-dht-keep-${stamp}`)
+    mkdirSync(legacyDir, { recursive: true })
+    mkdirSync(portableRoot, { recursive: true })
+    writeFileSync(join(legacyDir, 'dht.dat'), 'legacy-v4')
+    writeFileSync(join(portableRoot, 'dht.dat'), 'portable-live')
+
+    reclaimLegacyDhtFiles(legacyDir, portableRoot, { overwrite: false })
+
+    expect(existsSync(join(legacyDir, 'dht.dat'))).toBe(false)
+    expect(readFileSync(join(portableRoot, 'dht.dat'), 'utf8')).toBe('portable-live')
+    rmSync(portableRoot, { recursive: true, force: true })
+    rmSync(legacyDir, { recursive: true, force: true })
+  })
+
+  it('回收后若仍有其他文件则保留 AppData 目录', () => {
+    const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`
+    const legacyDir = join(tmpdir(), `imfile-legacy-dht-keepdir-${stamp}`)
+    const portableRoot = join(tmpdir(), `imfile-portable-dht-keepdir-${stamp}`)
+    mkdirSync(legacyDir, { recursive: true })
+    mkdirSync(portableRoot, { recursive: true })
+    writeFileSync(join(legacyDir, 'dht.dat'), 'legacy-v4')
+    writeFileSync(join(legacyDir, 'user.json'), '{}')
+
+    reclaimLegacyDhtFiles(legacyDir, portableRoot, { overwrite: true })
+
+    expect(existsSync(join(legacyDir, 'dht.dat'))).toBe(false)
+    expect(existsSync(join(legacyDir, 'user.json'))).toBe(true)
+    rmSync(legacyDir, { recursive: true, force: true })
+    rmSync(portableRoot, { recursive: true, force: true })
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

修复 Windows ZIP 便携版从 `%APPDATA%\imFile` 迁移配置后，`dht-file-path` / `dht-file-path6` 仍指向 AppData 的问题。

用户在 [#407 评论](https://github.com/imfile-io/imfile-desktop/issues/407#issuecomment-5257628770) 中反馈：#409/#410 只清理空目录，但迁移后的 `system.json` 仍带着旧绝对路径。`electron-store` 不会覆盖已有键，go-aria2 每次启动都向 AppData 写入 `dht.dat` / `dht6.dat`，目录因此非空，空目录清理永远不触发。其余路径（如 `save-session`）已正确指向便携目录。

本次同时做了两层纠正：

1. **启动最早阶段**（`portable-userdata.js`）：重定向 `userData` 后立刻改写便携目录 `system.json` 中的两个 DHT 键，并回收 AppData 残留的 `dht.dat` / `dht6.dat`。
2. **ConfigManager 兜底**：便携模式初始化时再次强制更新这两个键，避免 JSON 改写失败或键已载入内存。

回收策略：

- 若本次刚从 AppData 路径改写过来，用残留文件覆盖便携副本（引擎此前一直在往 AppData 写，残留文件更新）。
- 若用户已手动把路径改到便携目录，只删除 AppData 残留，不覆盖便携目录中的活文件。
- 回收后若 AppData 目录已空，继续走原有空目录清理。

## Related Issues

Fixes #407

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?

### 测试

- `pnpm run test`：58 files / 372 tests 通过
- `pnpm run lint`：通过

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11423269-7271-47e2-ad94-56cd179018ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11423269-7271-47e2-ad94-56cd179018ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

