### PR TITLE
fix(portable): 按审计意见收紧 DHT 路径改写与文件回收范围

### DIFF
--- a/src/main/core/ConfigManager.js
+++ b/src/main/core/ConfigManager.js
@@ -225,9 +225,10 @@ export default class ConfigManager {
   }
 
   /**
-   * 便携模式下强制将 dht-file-path / dht-file-path6 改到程序目录。
+   * 便携模式下将仍指向旧 AppData 的 dht-file-path / dht-file-path6 改到程序目录。
    * 从 AppData 迁移的 system.json 会带上旧绝对路径，electron-store 不会覆盖已有键，
    * 引擎会持续向 %APPDATA%\\imFile 写入 dht.dat，空目录清理因此失效。
+   * 用户自定义的外部路径（如共享盘）保持不变。
    */
   fixPortableDhtPaths () {
     const portableRoot = getPortableExecutableDir()
@@ -235,10 +236,14 @@ export default class ConfigManager {
       return
     }
 
+    const legacyDir = this.getLegacyUserDataDir()
     const fixes = collectPortableDhtPathFixes({
       'dht-file-path': this.systemConfig.get('dht-file-path'),
       'dht-file-path6': this.systemConfig.get('dht-file-path6')
-    }, portableRoot)
+    }, portableRoot, {
+      legacyDir,
+      appDataDir: this.getAppDataDir()
+    })
 
     const previousPaths = []
     for (const { key, from, to } of fixes) {
@@ -248,7 +253,6 @@ export default class ConfigManager {
       }
     }
 
-    const legacyDir = this.getLegacyUserDataDir()
     const overwrite = previousPaths.some((p) => isPathInsideDir(p, legacyDir))
     reclaimLegacyDhtFiles(legacyDir, portableRoot, {
       overwrite,
@@ -260,6 +264,14 @@ export default class ConfigManager {
     try {
       const appName = typeof app.getName === 'function' ? app.getName() : 'imFile'
       return resolve(app.getPath('appData'), appName || 'imFile')
+    } catch {
+      return ''
+    }
+  }
+
+  getAppDataDir () {
+    try {
+      return resolve(app.getPath('appData'))
     } catch {
       return ''
     }

--- a/src/main/core/ConfigManager.js
+++ b/src/main/core/ConfigManager.js
@@ -11,9 +11,11 @@ import {
 } from '../utils/index'
 import {
   collectPortableDhtPathFixes,
-  isPathInsideDir
+  getRememberedLegacyUserDataDir,
+  isPathInsideDir,
+  isSameFilePath
 } from '../utils/portableDhtPaths'
-import { reclaimLegacyDhtFiles } from '../utils/portableLegacyCleanup'
+import { reclaimRewrittenLegacyDhtFiles } from '../utils/portableLegacyCleanup'
 import {
   APP_RUN_MODE,
   APP_THEME,
@@ -208,14 +210,14 @@ export default class ConfigManager {
     try {
       const normalizedDir = resolve(String(currentDir))
       const normalizedRoot = resolve(portableRoot)
-      if (normalizedDir.toLowerCase().startsWith(normalizedRoot.toLowerCase())) {
+      if (isPathInsideDir(normalizedDir, normalizedRoot)) {
         return
       }
       const systemDownloads = resolve(app.getPath('downloads'))
       const appDataDir = resolve(app.getPath('appData'))
       if (
-        normalizedDir.toLowerCase() === systemDownloads.toLowerCase() ||
-        normalizedDir.toLowerCase().startsWith(appDataDir.toLowerCase())
+        isSameFilePath(normalizedDir, systemDownloads) ||
+        isPathInsideDir(normalizedDir, appDataDir)
       ) {
         this.setSystemConfig('dir', portableDownloads)
       }
@@ -240,10 +242,7 @@ export default class ConfigManager {
     const fixes = collectPortableDhtPathFixes({
       'dht-file-path': this.systemConfig.get('dht-file-path'),
       'dht-file-path6': this.systemConfig.get('dht-file-path6')
-    }, portableRoot, {
-      legacyDir,
-      appDataDir: this.getAppDataDir()
-    })
+    }, portableRoot, { legacyDir })
 
     const previousPaths = []
     for (const { key, from, to } of fixes) {
@@ -253,25 +252,17 @@ export default class ConfigManager {
       }
     }
 
-    const overwrite = previousPaths.some((p) => isPathInsideDir(p, legacyDir))
-    reclaimLegacyDhtFiles(legacyDir, portableRoot, {
-      overwrite,
-      extraPaths: previousPaths
-    })
+    reclaimRewrittenLegacyDhtFiles(legacyDir, portableRoot, previousPaths)
   }
 
   getLegacyUserDataDir () {
+    const remembered = getRememberedLegacyUserDataDir()
+    if (remembered) {
+      return resolve(remembered)
+    }
     try {
       const appName = typeof app.getName === 'function' ? app.getName() : 'imFile'
       return resolve(app.getPath('appData'), appName || 'imFile')
-    } catch {
-      return ''
-    }
-  }
-
-  getAppDataDir () {
-    try {
-      return resolve(app.getPath('appData'))
     } catch {
       return ''
     }

--- a/src/main/portable-userdata.js
+++ b/src/main/portable-userdata.js
@@ -9,8 +9,8 @@
 import { cpSync, existsSync, readdirSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { app } from 'electron'
-import { isPathInsideDir, rewritePortableDhtPathsInSystemJson } from './utils/portableDhtPaths'
-import { reclaimLegacyDhtFiles, removeEmptyLegacyUserDataDir } from './utils/portableLegacyCleanup'
+import { isSameFilePath, rememberLegacyUserDataDir, rewritePortableDhtPathsInSystemJson } from './utils/portableDhtPaths'
+import { reclaimRewrittenLegacyDhtFiles } from './utils/portableLegacyCleanup'
 
 const PORTABLE_DATA_FILES = new Set([
   'user.json',
@@ -79,7 +79,7 @@ function shouldMigratePortableEntry (name) {
  * 仅迁移配置与引擎数据，不复制 AppData 下的 logs/Cache 等目录。
  */
 function migrateLegacyUserDataIfNeeded (legacyDir, portableRoot) {
-  if (!legacyDir || legacyDir === portableRoot) {
+  if (!legacyDir || isSameFilePath(legacyDir, portableRoot)) {
     return
   }
   if (existsSync(join(portableRoot, 'user.json')) || existsSync(join(portableRoot, 'system.json'))) {
@@ -134,6 +134,7 @@ function getPortableCacheDir (portableRoot) {
 const defaultUserData = app.getPath('userData')
 const portableRoot = resolvePortableRoot()
 if (portableRoot) {
+  rememberLegacyUserDataDir(defaultUserData)
   migrateLegacyUserDataIfNeeded(defaultUserData, portableRoot)
   process.env.PORTABLE_EXECUTABLE_DIR = portableRoot
   app.setPath('userData', portableRoot)
@@ -145,15 +146,7 @@ if (portableRoot) {
   const { previousPaths } = rewritePortableDhtPathsInSystemJson(
     join(portableRoot, 'system.json'),
     portableRoot,
-    {
-      legacyDir: defaultUserData,
-      appDataDir: app.getPath('appData')
-    }
+    { legacyDir: defaultUserData }
   )
-  const overwriteLegacyDht = previousPaths.some((p) => isPathInsideDir(p, defaultUserData))
-  reclaimLegacyDhtFiles(defaultUserData, portableRoot, {
-    overwrite: overwriteLegacyDht,
-    extraPaths: previousPaths
-  })
-  removeEmptyLegacyUserDataDir(defaultUserData)
+  reclaimRewrittenLegacyDhtFiles(defaultUserData, portableRoot, previousPaths)
 }

--- a/src/main/portable-userdata.js
+++ b/src/main/portable-userdata.js
@@ -144,7 +144,11 @@ if (portableRoot) {
   // 仍是 AppData 绝对路径，electron-store 不会用 defaults 覆盖已有键。
   const { previousPaths } = rewritePortableDhtPathsInSystemJson(
     join(portableRoot, 'system.json'),
-    portableRoot
+    portableRoot,
+    {
+      legacyDir: defaultUserData,
+      appDataDir: app.getPath('appData')
+    }
   )
   const overwriteLegacyDht = previousPaths.some((p) => isPathInsideDir(p, defaultUserData))
   reclaimLegacyDhtFiles(defaultUserData, portableRoot, {

--- a/src/main/utils/portableDhtPaths.js
+++ b/src/main/utils/portableDhtPaths.js
@@ -46,19 +46,26 @@ export function getPortableDhtFilePath (portableRoot, fileName) {
   return resolve(portableRoot, fileName)
 }
 
+let rememberedLegacyUserDataDir = ''
+
+/** 记录便携重定向前的默认 userData，供 ConfigManager 与启动清理使用同一路径。 */
+export function rememberLegacyUserDataDir (dir) {
+  rememberedLegacyUserDataDir = typeof dir === 'string' ? dir : ''
+}
+
+export function getRememberedLegacyUserDataDir () {
+  return rememberedLegacyUserDataDir
+}
+
 /**
- * 是否属于应纠正的旧 DHT 位置：空值，或落在旧 AppData userData / AppData 根下。
- * 自定义外部路径（如共享盘）不视为残留，与 fixPortableDownloadDir 策略一致。
+ * 是否属于应纠正的旧 DHT 位置：空值，或落在旧 AppData userData 内。
+ * 自定义外部路径（如共享盘、AppData 下其他目录）不视为残留。
  */
 export function isLegacyPortableDhtLocation (filePath, options = {}) {
   if (!filePath || !String(filePath).trim()) {
     return true
   }
-  const { legacyDir, appDataDir } = options
-  return Boolean(
-    (legacyDir && isPathInsideDir(filePath, legacyDir)) ||
-    (appDataDir && isPathInsideDir(filePath, appDataDir))
-  )
+  return Boolean(options.legacyDir && isPathInsideDir(filePath, options.legacyDir))
 }
 
 /**

--- a/src/main/utils/portableDhtPaths.js
+++ b/src/main/utils/portableDhtPaths.js
@@ -47,11 +47,27 @@ export function getPortableDhtFilePath (portableRoot, fileName) {
 }
 
 /**
+ * 是否属于应纠正的旧 DHT 位置：空值，或落在旧 AppData userData / AppData 根下。
+ * 自定义外部路径（如共享盘）不视为残留，与 fixPortableDownloadDir 策略一致。
+ */
+export function isLegacyPortableDhtLocation (filePath, options = {}) {
+  if (!filePath || !String(filePath).trim()) {
+    return true
+  }
+  const { legacyDir, appDataDir } = options
+  return Boolean(
+    (legacyDir && isPathInsideDir(filePath, legacyDir)) ||
+    (appDataDir && isPathInsideDir(filePath, appDataDir))
+  )
+}
+
+/**
  * 计算需要改写到便携根目录的 DHT 路径。
+ * 只纠正空值和旧 AppData 残留；用户自定义的外部路径保持不变。
  * electron-store 对已存在的键不会套用 defaults，迁移后的绝对路径会一直指向 AppData。
  * @returns {{ key: string, from: string, to: string }[]}
  */
-export function collectPortableDhtPathFixes (currentByKey, portableRoot) {
+export function collectPortableDhtPathFixes (currentByKey, portableRoot, options = {}) {
   if (!currentByKey || !portableRoot) {
     return []
   }
@@ -60,13 +76,18 @@ export function collectPortableDhtPathFixes (currentByKey, portableRoot) {
   for (const [key, fileName] of PORTABLE_DHT_PATH_KEYS) {
     const expected = getPortableDhtFilePath(portableRoot, fileName)
     const current = currentByKey[key]
-    if (!current || !isSameFilePath(current, expected)) {
-      fixes.push({
-        key,
-        from: current ? String(current) : '',
-        to: expected
-      })
+    const currentStr = current == null ? '' : String(current).trim()
+    if (currentStr && isSameFilePath(currentStr, expected)) {
+      continue
     }
+    if (currentStr && !isLegacyPortableDhtLocation(currentStr, options)) {
+      continue
+    }
+    fixes.push({
+      key,
+      from: currentStr,
+      to: expected
+    })
   }
   return fixes
 }
@@ -75,7 +96,7 @@ export function collectPortableDhtPathFixes (currentByKey, portableRoot) {
  * 读取便携目录 system.json，将残留的 DHT 绝对路径改写为便携根目录。
  * @returns {{ changed: boolean, previousPaths: string[] }}
  */
-export function rewritePortableDhtPathsInSystemJson (systemJsonPath, portableRoot) {
+export function rewritePortableDhtPathsInSystemJson (systemJsonPath, portableRoot, options = {}) {
   const empty = { changed: false, previousPaths: [] }
   if (!systemJsonPath || !portableRoot || !existsSync(systemJsonPath)) {
     return empty
@@ -87,7 +108,7 @@ export function rewritePortableDhtPathsInSystemJson (systemJsonPath, portableRoo
       return empty
     }
 
-    const fixes = collectPortableDhtPathFixes(data, portableRoot)
+    const fixes = collectPortableDhtPathFixes(data, portableRoot, options)
     if (fixes.length === 0) {
       return empty
     }

--- a/src/main/utils/portableLegacyCleanup.js
+++ b/src/main/utils/portableLegacyCleanup.js
@@ -26,48 +26,39 @@ export function removeEmptyLegacyUserDataDir (legacyDir) {
 }
 
 /**
- * 回收 AppData 中残留的 dht.dat / dht6.dat。
- * 迁移后若 system.json 仍指向旧绝对路径，引擎会持续写入这些文件，
- * 导致目录非空、空目录清理永远不触发。
+ * 仅回收「本次刚从配置里改走」的旧 AppData DHT 文件。
+ * 不会在每次便携启动时扫删 legacyDir 下所有 dht.dat，避免安装版与便携版并存时毁掉安装版 DHT 表。
  *
  * overwrite=true 时用残留文件覆盖便携目录副本（引擎此前一直在往 AppData 写，残留文件更新）。
- * 仅处理落在 legacyDir 内的文件，extraPaths 指向自定义外部位置时不会删除。
  */
 export function reclaimLegacyDhtFiles (legacyDir, portableRoot, options = {}) {
   const { overwrite = false, extraPaths = [] } = options
-  if (!portableRoot) {
+  if (!portableRoot || !legacyDir) {
     return
   }
-  if (legacyDir && isSameFilePath(legacyDir, portableRoot)) {
+  if (isSameFilePath(legacyDir, portableRoot)) {
     return
-  }
-
-  const targets = []
-  if (legacyDir) {
-    for (const name of LEGACY_DHT_FILE_NAMES) {
-      targets.push(join(legacyDir, name))
-    }
-  }
-  for (const extra of extraPaths) {
-    if (typeof extra === 'string' && extra) {
-      targets.push(extra)
-    }
   }
 
   const seen = new Set()
-  for (const src of targets) {
+  for (const extra of extraPaths) {
+    if (typeof extra !== 'string' || !extra) {
+      continue
+    }
+
     let normalized
     try {
-      normalized = resolve(src)
+      normalized = resolve(extra)
     } catch {
       continue
     }
-    if (seen.has(normalized)) {
+    const seenKey = process.platform === 'win32' ? normalized.toLowerCase() : normalized
+    if (seen.has(seenKey)) {
       continue
     }
-    seen.add(normalized)
+    seen.add(seenKey)
 
-    const name = basename(normalized)
+    const name = basename(normalized).toLowerCase()
     if (!LEGACY_DHT_FILE_NAMES.has(name)) {
       continue
     }
@@ -77,8 +68,7 @@ export function reclaimLegacyDhtFiles (legacyDir, portableRoot, options = {}) {
     if (isPathInsideDir(normalized, portableRoot)) {
       continue
     }
-    // 只回收旧 AppData userData 内的残留，避免删掉自定义外部 DHT 文件
-    if (!legacyDir || !isPathInsideDir(normalized, legacyDir)) {
+    if (!isPathInsideDir(normalized, legacyDir)) {
       continue
     }
 
@@ -94,4 +84,21 @@ export function reclaimLegacyDhtFiles (legacyDir, portableRoot, options = {}) {
   }
 
   removeEmptyLegacyUserDataDir(legacyDir)
+}
+
+/**
+ * 对本次改写出的旧路径做回收；没有改写时只尝试删除空的 AppData 目录。
+ */
+export function reclaimRewrittenLegacyDhtFiles (legacyDir, portableRoot, previousPaths = []) {
+  const extraPaths = (previousPaths || []).filter((p) => (
+    typeof p === 'string' && p && isPathInsideDir(p, legacyDir)
+  ))
+  if (extraPaths.length === 0) {
+    removeEmptyLegacyUserDataDir(legacyDir)
+    return
+  }
+  reclaimLegacyDhtFiles(legacyDir, portableRoot, {
+    overwrite: true,
+    extraPaths
+  })
 }

--- a/src/main/utils/portableLegacyCleanup.js
+++ b/src/main/utils/portableLegacyCleanup.js
@@ -31,6 +31,7 @@ export function removeEmptyLegacyUserDataDir (legacyDir) {
  * 导致目录非空、空目录清理永远不触发。
  *
  * overwrite=true 时用残留文件覆盖便携目录副本（引擎此前一直在往 AppData 写，残留文件更新）。
+ * 仅处理落在 legacyDir 内的文件，extraPaths 指向自定义外部位置时不会删除。
  */
 export function reclaimLegacyDhtFiles (legacyDir, portableRoot, options = {}) {
   const { overwrite = false, extraPaths = [] } = options
@@ -74,6 +75,10 @@ export function reclaimLegacyDhtFiles (legacyDir, portableRoot, options = {}) {
       continue
     }
     if (isPathInsideDir(normalized, portableRoot)) {
+      continue
+    }
+    // 只回收旧 AppData userData 内的残留，避免删掉自定义外部 DHT 文件
+    if (!legacyDir || !isPathInsideDir(normalized, legacyDir)) {
       continue
     }
 

--- a/tests/main/core/ConfigManager.test.js
+++ b/tests/main/core/ConfigManager.test.js
@@ -25,6 +25,7 @@ vi.mock('electron-log', () => ({
 }))
 
 const { default: ConfigManager } = await import('../../../src/main/core/ConfigManager.js')
+const { rememberLegacyUserDataDir } = await import('../../../src/main/utils/portableDhtPaths.js')
 
 describe('ConfigManager', () => {
   let manager
@@ -38,6 +39,7 @@ describe('ConfigManager', () => {
   afterEach(() => {
     delete process.env.PORTABLE_EXECUTABLE_DIR
     delete process.env.SSAPI_BUILD_DEFAULT_BASE_URL
+    rememberLegacyUserDataDir('')
   })
 
   it('初始化用户与系统默认配置', () => {
@@ -109,6 +111,14 @@ describe('ConfigManager', () => {
     expect(manager.getSystemConfig('dir')).toBe('/portable/Downloads')
   })
 
+  it('便携模式下不把前缀相似的自定义下载目录当成系统下载', () => {
+    process.env.PORTABLE_EXECUTABLE_DIR = '/portable'
+    manager.setSystemConfig('dir', '/mock/downloads-extra')
+    manager.fixPortableDownloadDir()
+
+    expect(manager.getSystemConfig('dir')).toBe('/mock/downloads-extra')
+  })
+
   it('便携模式下将残留的 AppData DHT 路径改写到程序目录', () => {
     process.env.PORTABLE_EXECUTABLE_DIR = '/portable'
     manager.setSystemConfig('dht-file-path', '/mock/appData/imFile/dht.dat')
@@ -127,6 +137,16 @@ describe('ConfigManager', () => {
 
     expect(manager.getSystemConfig('dht-file-path')).toBe('/portable/dht.dat')
     expect(manager.getSystemConfig('dht-file-path6')).toBe('/portable/dht6.dat')
+  })
+
+  it('便携模式下不改写 AppData 下其他目录的 DHT 路径', () => {
+    process.env.PORTABLE_EXECUTABLE_DIR = '/portable'
+    manager.setSystemConfig('dht-file-path', '/mock/appData/other/dht.dat')
+    manager.setSystemConfig('dht-file-path6', '/mock/appData/other/dht6.dat')
+    manager.fixPortableDhtPaths()
+
+    expect(manager.getSystemConfig('dht-file-path')).toBe('/mock/appData/other/dht.dat')
+    expect(manager.getSystemConfig('dht-file-path6')).toBe('/mock/appData/other/dht6.dat')
   })
 
   it('便携模式下保留自定义外部 DHT 路径', () => {

--- a/tests/main/core/ConfigManager.test.js
+++ b/tests/main/core/ConfigManager.test.js
@@ -129,6 +129,16 @@ describe('ConfigManager', () => {
     expect(manager.getSystemConfig('dht-file-path6')).toBe('/portable/dht6.dat')
   })
 
+  it('便携模式下保留自定义外部 DHT 路径', () => {
+    process.env.PORTABLE_EXECUTABLE_DIR = '/portable'
+    manager.setSystemConfig('dht-file-path', '/shared/dht/dht.dat')
+    manager.setSystemConfig('dht-file-path6', '/shared/dht/dht6.dat')
+    manager.fixPortableDhtPaths()
+
+    expect(manager.getSystemConfig('dht-file-path')).toBe('/shared/dht/dht.dat')
+    expect(manager.getSystemConfig('dht-file-path6')).toBe('/shared/dht/dht6.dat')
+  })
+
   it('fixSystemConfig 在便携模式下同步纠正 DHT 路径', () => {
     process.env.PORTABLE_EXECUTABLE_DIR = '/portable'
     manager.setSystemConfig('dht-file-path', '/mock/appData/imFile/dht.dat')

--- a/tests/main/utils/portableDhtPaths.test.js
+++ b/tests/main/utils/portableDhtPaths.test.js
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   collectPortableDhtPathFixes,
+  isLegacyPortableDhtLocation,
   isPathInsideDir,
   isSameFilePath,
   rewritePortableDhtPathsInSystemJson
@@ -40,21 +41,26 @@ describe('isSameFilePath / isPathInsideDir', () => {
 })
 
 describe('collectPortableDhtPathFixes', () => {
+  const legacyOptions = {
+    legacyDir: '/mock/appData/imFile',
+    appDataDir: '/mock/appData'
+  }
+
   it('将 AppData 残留路径改写到便携根目录', () => {
     const fixes = collectPortableDhtPathFixes({
-      'dht-file-path': 'C:\\Users\\User\\AppData\\Roaming\\imFile\\dht.dat',
-      'dht-file-path6': 'C:\\Users\\User\\AppData\\Roaming\\imFile\\dht6.dat'
-    }, '/portable')
+      'dht-file-path': '/mock/appData/imFile/dht.dat',
+      'dht-file-path6': '/mock/appData/imFile/dht6.dat'
+    }, '/portable', legacyOptions)
 
     expect(fixes).toEqual([
       {
         key: 'dht-file-path',
-        from: 'C:\\Users\\User\\AppData\\Roaming\\imFile\\dht.dat',
+        from: '/mock/appData/imFile/dht.dat',
         to: '/portable/dht.dat'
       },
       {
         key: 'dht-file-path6',
-        from: 'C:\\Users\\User\\AppData\\Roaming\\imFile\\dht6.dat',
+        from: '/mock/appData/imFile/dht6.dat',
         to: '/portable/dht6.dat'
       }
     ])
@@ -64,15 +70,50 @@ describe('collectPortableDhtPathFixes', () => {
     expect(collectPortableDhtPathFixes({
       'dht-file-path': '/portable/dht.dat',
       'dht-file-path6': '/portable/dht6.dat'
-    }, '/portable')).toEqual([])
+    }, '/portable', legacyOptions)).toEqual([])
   })
 
   it('空值或缺省键也会补到便携目录', () => {
-    const fixes = collectPortableDhtPathFixes({}, '/portable')
+    const fixes = collectPortableDhtPathFixes({}, '/portable', legacyOptions)
     expect(fixes.map((item) => item.to)).toEqual([
       '/portable/dht.dat',
       '/portable/dht6.dat'
     ])
+  })
+
+  it('保留用户自定义的外部 DHT 路径', () => {
+    expect(collectPortableDhtPathFixes({
+      'dht-file-path': '/shared/dht/dht.dat',
+      'dht-file-path6': '/shared/dht/dht6.dat'
+    }, '/portable', legacyOptions)).toEqual([])
+  })
+
+  it('AppData 根下但不在 imFile 目录的路径仍视为残留', () => {
+    const fixes = collectPortableDhtPathFixes({
+      'dht-file-path': '/mock/appData/other/dht.dat',
+      'dht-file-path6': '/portable/dht6.dat'
+    }, '/portable', legacyOptions)
+    expect(fixes).toEqual([
+      {
+        key: 'dht-file-path',
+        from: '/mock/appData/other/dht.dat',
+        to: '/portable/dht.dat'
+      }
+    ])
+  })
+})
+
+describe('isLegacyPortableDhtLocation', () => {
+  const options = {
+    legacyDir: '/mock/appData/imFile',
+    appDataDir: '/mock/appData'
+  }
+
+  it('空值与 AppData 残留为 true，共享盘路径为 false', () => {
+    expect(isLegacyPortableDhtLocation('', options)).toBe(true)
+    expect(isLegacyPortableDhtLocation('/mock/appData/imFile/dht.dat', options)).toBe(true)
+    expect(isLegacyPortableDhtLocation('/mock/appData/other/dht.dat', options)).toBe(true)
+    expect(isLegacyPortableDhtLocation('/shared/dht/dht.dat', options)).toBe(false)
   })
 })
 
@@ -87,7 +128,10 @@ describe('rewritePortableDhtPathsInSystemJson', () => {
       'save-session': '/portable/session.json'
     }, null, 2))
 
-    const result = rewritePortableDhtPathsInSystemJson(systemJsonPath, portableRoot)
+    const result = rewritePortableDhtPathsInSystemJson(systemJsonPath, portableRoot, {
+      legacyDir: '/mock/appData/imFile',
+      appDataDir: '/mock/appData'
+    })
 
     expect(result.changed).toBe(true)
     expect(result.previousPaths).toEqual([
@@ -111,6 +155,24 @@ describe('rewritePortableDhtPathsInSystemJson', () => {
     writeFileSync(systemJsonPath, JSON.stringify(payload))
 
     const result = rewritePortableDhtPathsInSystemJson(systemJsonPath, portableRoot)
+    expect(result.changed).toBe(false)
+    expect(JSON.parse(readFileSync(systemJsonPath, 'utf8'))).toEqual(payload)
+  })
+
+  it('自定义外部 DHT 路径不写入 system.json', () => {
+    const portableRoot = makeTempDir('imfile-portable-dht-custom')
+    const systemJsonPath = join(portableRoot, 'system.json')
+    const payload = {
+      'dht-file-path': '/shared/dht/dht.dat',
+      'dht-file-path6': '/shared/dht/dht6.dat'
+    }
+    writeFileSync(systemJsonPath, JSON.stringify(payload))
+
+    const result = rewritePortableDhtPathsInSystemJson(systemJsonPath, portableRoot, {
+      legacyDir: '/mock/appData/imFile',
+      appDataDir: '/mock/appData'
+    })
+
     expect(result.changed).toBe(false)
     expect(JSON.parse(readFileSync(systemJsonPath, 'utf8'))).toEqual(payload)
   })

--- a/tests/main/utils/portableDhtPaths.test.js
+++ b/tests/main/utils/portableDhtPaths.test.js
@@ -4,9 +4,11 @@ import { tmpdir } from 'node:os'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   collectPortableDhtPathFixes,
+  getRememberedLegacyUserDataDir,
   isLegacyPortableDhtLocation,
   isPathInsideDir,
   isSameFilePath,
+  rememberLegacyUserDataDir,
   rewritePortableDhtPathsInSystemJson
 } from '../../../src/main/utils/portableDhtPaths'
 
@@ -20,9 +22,18 @@ function makeTempDir (prefix) {
 }
 
 afterEach(() => {
+  rememberLegacyUserDataDir('')
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true })
   }
+})
+
+describe('rememberLegacyUserDataDir', () => {
+  it('记录并读取便携重定向前的 userData', () => {
+    expect(getRememberedLegacyUserDataDir()).toBe('')
+    rememberLegacyUserDataDir('/mock/appData/imFile')
+    expect(getRememberedLegacyUserDataDir()).toBe('/mock/appData/imFile')
+  })
 })
 
 describe('isSameFilePath / isPathInsideDir', () => {
@@ -42,8 +53,7 @@ describe('isSameFilePath / isPathInsideDir', () => {
 
 describe('collectPortableDhtPathFixes', () => {
   const legacyOptions = {
-    legacyDir: '/mock/appData/imFile',
-    appDataDir: '/mock/appData'
+    legacyDir: '/mock/appData/imFile'
   }
 
   it('将 AppData 残留路径改写到便携根目录', () => {
@@ -88,31 +98,23 @@ describe('collectPortableDhtPathFixes', () => {
     }, '/portable', legacyOptions)).toEqual([])
   })
 
-  it('AppData 根下但不在 imFile 目录的路径仍视为残留', () => {
-    const fixes = collectPortableDhtPathFixes({
+  it('AppData 下其他目录的路径保持不变', () => {
+    expect(collectPortableDhtPathFixes({
       'dht-file-path': '/mock/appData/other/dht.dat',
       'dht-file-path6': '/portable/dht6.dat'
-    }, '/portable', legacyOptions)
-    expect(fixes).toEqual([
-      {
-        key: 'dht-file-path',
-        from: '/mock/appData/other/dht.dat',
-        to: '/portable/dht.dat'
-      }
-    ])
+    }, '/portable', legacyOptions)).toEqual([])
   })
 })
 
 describe('isLegacyPortableDhtLocation', () => {
   const options = {
-    legacyDir: '/mock/appData/imFile',
-    appDataDir: '/mock/appData'
+    legacyDir: '/mock/appData/imFile'
   }
 
-  it('空值与 AppData 残留为 true，共享盘路径为 false', () => {
+  it('空值与旧 userData 残留为 true，其他路径为 false', () => {
     expect(isLegacyPortableDhtLocation('', options)).toBe(true)
     expect(isLegacyPortableDhtLocation('/mock/appData/imFile/dht.dat', options)).toBe(true)
-    expect(isLegacyPortableDhtLocation('/mock/appData/other/dht.dat', options)).toBe(true)
+    expect(isLegacyPortableDhtLocation('/mock/appData/other/dht.dat', options)).toBe(false)
     expect(isLegacyPortableDhtLocation('/shared/dht/dht.dat', options)).toBe(false)
   })
 })
@@ -129,8 +131,7 @@ describe('rewritePortableDhtPathsInSystemJson', () => {
     }, null, 2))
 
     const result = rewritePortableDhtPathsInSystemJson(systemJsonPath, portableRoot, {
-      legacyDir: '/mock/appData/imFile',
-      appDataDir: '/mock/appData'
+      legacyDir: '/mock/appData/imFile'
     })
 
     expect(result.changed).toBe(true)
@@ -169,8 +170,7 @@ describe('rewritePortableDhtPathsInSystemJson', () => {
     writeFileSync(systemJsonPath, JSON.stringify(payload))
 
     const result = rewritePortableDhtPathsInSystemJson(systemJsonPath, portableRoot, {
-      legacyDir: '/mock/appData/imFile',
-      appDataDir: '/mock/appData'
+      legacyDir: '/mock/appData/imFile'
     })
 
     expect(result.changed).toBe(false)

--- a/tests/main/utils/portableLegacyCleanup.test.js
+++ b/tests/main/utils/portableLegacyCleanup.test.js
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { describe, expect, it } from 'vitest'
 import {
   reclaimLegacyDhtFiles,
+  reclaimRewrittenLegacyDhtFiles,
   removeEmptyLegacyUserDataDir
 } from '../../../src/main/utils/portableLegacyCleanup'
 
@@ -41,7 +42,7 @@ describe('removeEmptyLegacyUserDataDir', () => {
 })
 
 describe('reclaimLegacyDhtFiles', () => {
-  it('overwrite 时把 AppData 残留 DHT 文件迁到便携目录并删除旧文件', () => {
+  it('只回收 extraPaths 中且位于 legacyDir 内的 DHT 文件', () => {
     const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`
     const legacyDir = join(tmpdir(), `imfile-legacy-dht-${stamp}`)
     const portableRoot = join(tmpdir(), `imfile-portable-dht-${stamp}`)
@@ -51,13 +52,32 @@ describe('reclaimLegacyDhtFiles', () => {
     writeFileSync(join(legacyDir, 'dht6.dat'), 'legacy-v6')
     writeFileSync(join(portableRoot, 'dht.dat'), 'stale-v4')
 
-    reclaimLegacyDhtFiles(legacyDir, portableRoot, { overwrite: true })
+    reclaimLegacyDhtFiles(legacyDir, portableRoot, {
+      overwrite: true,
+      extraPaths: [join(legacyDir, 'dht.dat'), join(legacyDir, 'dht6.dat')]
+    })
 
     expect(existsSync(join(legacyDir, 'dht.dat'))).toBe(false)
     expect(existsSync(join(legacyDir, 'dht6.dat'))).toBe(false)
     expect(readFileSync(join(portableRoot, 'dht.dat'), 'utf8')).toBe('legacy-v4')
     expect(readFileSync(join(portableRoot, 'dht6.dat'), 'utf8')).toBe('legacy-v6')
     expect(existsSync(legacyDir)).toBe(false)
+    rmSync(portableRoot, { recursive: true, force: true })
+  })
+
+  it('没有 extraPaths 时不扫删 AppData 中的 DHT 文件', () => {
+    const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`
+    const legacyDir = join(tmpdir(), `imfile-legacy-dht-keepall-${stamp}`)
+    const portableRoot = join(tmpdir(), `imfile-portable-dht-keepall-${stamp}`)
+    mkdirSync(legacyDir, { recursive: true })
+    mkdirSync(portableRoot, { recursive: true })
+    writeFileSync(join(legacyDir, 'dht.dat'), 'install-live')
+
+    reclaimLegacyDhtFiles(legacyDir, portableRoot, { overwrite: true })
+
+    expect(readFileSync(join(legacyDir, 'dht.dat'), 'utf8')).toBe('install-live')
+    expect(existsSync(join(portableRoot, 'dht.dat'))).toBe(false)
+    rmSync(legacyDir, { recursive: true, force: true })
     rmSync(portableRoot, { recursive: true, force: true })
   })
 
@@ -70,7 +90,10 @@ describe('reclaimLegacyDhtFiles', () => {
     writeFileSync(join(legacyDir, 'dht.dat'), 'legacy-v4')
     writeFileSync(join(portableRoot, 'dht.dat'), 'portable-live')
 
-    reclaimLegacyDhtFiles(legacyDir, portableRoot, { overwrite: false })
+    reclaimLegacyDhtFiles(legacyDir, portableRoot, {
+      overwrite: false,
+      extraPaths: [join(legacyDir, 'dht.dat')]
+    })
 
     expect(existsSync(join(legacyDir, 'dht.dat'))).toBe(false)
     expect(readFileSync(join(portableRoot, 'dht.dat'), 'utf8')).toBe('portable-live')
@@ -111,11 +134,48 @@ describe('reclaimLegacyDhtFiles', () => {
     writeFileSync(join(legacyDir, 'dht.dat'), 'legacy-v4')
     writeFileSync(join(legacyDir, 'user.json'), '{}')
 
-    reclaimLegacyDhtFiles(legacyDir, portableRoot, { overwrite: true })
+    reclaimLegacyDhtFiles(legacyDir, portableRoot, {
+      overwrite: true,
+      extraPaths: [join(legacyDir, 'dht.dat')]
+    })
 
     expect(existsSync(join(legacyDir, 'dht.dat'))).toBe(false)
     expect(existsSync(join(legacyDir, 'user.json'))).toBe(true)
     rmSync(legacyDir, { recursive: true, force: true })
     rmSync(portableRoot, { recursive: true, force: true })
+  })
+})
+
+describe('reclaimRewrittenLegacyDhtFiles', () => {
+  it('未改写时不删除 AppData DHT，只清理空目录', () => {
+    const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`
+    const legacyDir = join(tmpdir(), `imfile-legacy-dht-norewrite-${stamp}`)
+    const portableRoot = join(tmpdir(), `imfile-portable-dht-norewrite-${stamp}`)
+    mkdirSync(legacyDir, { recursive: true })
+    mkdirSync(portableRoot, { recursive: true })
+    writeFileSync(join(legacyDir, 'dht.dat'), 'install-live')
+
+    reclaimRewrittenLegacyDhtFiles(legacyDir, portableRoot, [])
+
+    expect(readFileSync(join(legacyDir, 'dht.dat'), 'utf8')).toBe('install-live')
+    rmSync(legacyDir, { recursive: true, force: true })
+    rmSync(portableRoot, { recursive: true, force: true })
+  })
+
+  it('改写自 AppData 的路径会覆盖便携副本并删除旧文件', () => {
+    const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`
+    const legacyDir = join(tmpdir(), `imfile-legacy-dht-rewrite-${stamp}`)
+    const portableRoot = join(tmpdir(), `imfile-portable-dht-rewrite-${stamp}`)
+    mkdirSync(legacyDir, { recursive: true })
+    mkdirSync(portableRoot, { recursive: true })
+    writeFileSync(join(legacyDir, 'dht.dat'), 'legacy-live')
+    writeFileSync(join(portableRoot, 'dht.dat'), 'stale-copy')
+
+    reclaimRewrittenLegacyDhtFiles(legacyDir, portableRoot, [join(legacyDir, 'dht.dat')])
+
+    expect(existsSync(join(legacyDir, 'dht.dat'))).toBe(false)
+    expect(readFileSync(join(portableRoot, 'dht.dat'), 'utf8')).toBe('legacy-live')
+    rmSync(portableRoot, { recursive: true, force: true })
+    rmSync(legacyDir, { recursive: true, force: true })
   })
 })

--- a/tests/main/utils/portableLegacyCleanup.test.js
+++ b/tests/main/utils/portableLegacyCleanup.test.js
@@ -78,6 +78,30 @@ describe('reclaimLegacyDhtFiles', () => {
     rmSync(legacyDir, { recursive: true, force: true })
   })
 
+  it('不删除 legacyDir 之外的自定义 DHT 文件', () => {
+    const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`
+    const legacyDir = join(tmpdir(), `imfile-legacy-dht-skip-${stamp}`)
+    const portableRoot = join(tmpdir(), `imfile-portable-dht-skip-${stamp}`)
+    const customDir = join(tmpdir(), `imfile-custom-dht-skip-${stamp}`)
+    mkdirSync(legacyDir, { recursive: true })
+    mkdirSync(portableRoot, { recursive: true })
+    mkdirSync(customDir, { recursive: true })
+    const customFile = join(customDir, 'dht.dat')
+    writeFileSync(customFile, 'custom-live')
+
+    reclaimLegacyDhtFiles(legacyDir, portableRoot, {
+      overwrite: true,
+      extraPaths: [customFile]
+    })
+
+    expect(existsSync(customFile)).toBe(true)
+    expect(readFileSync(customFile, 'utf8')).toBe('custom-live')
+    expect(existsSync(join(portableRoot, 'dht.dat'))).toBe(false)
+    rmSync(legacyDir, { recursive: true, force: true })
+    rmSync(portableRoot, { recursive: true, force: true })
+    rmSync(customDir, { recursive: true, force: true })
+  })
+
   it('回收后若仍有其他文件则保留 AppData 目录', () => {
     const stamp = `${Date.now()}-${Math.random().toString(16).slice(2)}`
     const legacyDir = join(tmpdir(), `imfile-legacy-dht-keepdir-${stamp}`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

跟进 [#446](https://github.com/imfile-io/imfile-desktop/pull/446) 审计意见，并再做多轮自审后收紧便携模式 DHT 路径改写与残留文件回收。

### 审计意见（#446）

1. 自定义 DHT 路径不应被强制改写。
2. `reclaimLegacyDhtFiles` 不应删除 `legacyDir` 之外的源文件。

### 自审追加（本轮）

1. **不再用整个 AppData 根判断残留**。只认空值或旧 `%APPDATA%\imFile`（`legacyDir`），`%APPDATA%` 下其他目录视为自定义路径。
2. **不再每次启动扫删 AppData 里全部 DHT 文件**。只回收「本次刚从配置改走」的路径；未改写时只清理空目录，避免安装版与便携版并存时毁掉安装版 DHT 表。
3. **统一旧 userData 路径**。启动时记住 `app.getPath('userData')` 的真实值，ConfigManager 不再只靠 `app.getName()` 重建。
4. **`fixPortableDownloadDir` 前缀误匹配**。改用带分隔符的目录判断，避免把 `/mock/downloads-extra` 当成系统下载目录。

#407 的 AppData 残留场景：首次纠正时仍会改写并回收真正的旧 userData DHT 文件。

## Related Issues

Related to #407
Addresses review on #446

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran app with your changes locally?

### 测试

- `pnpm run test`：58 files / 384 tests 通过
- `pnpm run lint`：通过

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11423269-7271-47e2-ad94-56cd179018ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11423269-7271-47e2-ad94-56cd179018ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

